### PR TITLE
fix: align pricing page with site theme

### DIFF
--- a/Frontendd/package-lock.json
+++ b/Frontendd/package-lock.json
@@ -80,7 +80,6 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1500,8 +1499,7 @@
         }
       ],
       "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsparticles/interaction-external-attract": {
       "version": "3.9.1",
@@ -1908,7 +1906,6 @@
       "version": "19.2.7",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1917,7 +1914,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1952,7 +1948,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2133,7 +2128,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2412,8 +2406,7 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -2496,7 +2489,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3003,7 +2995,6 @@
     "node_modules/jiti": {
       "version": "1.21.7",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3401,7 +3392,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3574,7 +3564,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3582,7 +3571,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3996,7 +3984,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4094,7 +4081,6 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4184,7 +4170,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4234,7 +4219,6 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/Frontendd/src/components/mvpblocks/designer-pricing.jsx
+++ b/Frontendd/src/components/mvpblocks/designer-pricing.jsx
@@ -1,35 +1,28 @@
-import { cn } from "../../lib/utils";
-
 export default function DesignerPricing() {
   return (
-    <div className="relative min-h-full w-full bg-white font-sans text-black antialiased">
-      <section className="relative mr-auto ml-auto max-w-7xl pt-16 pr-4 pb-16 pl-4 sm:px-6 sm:py-24 lg:px-8">
-        <div className="mb-16 text-center sm:mb-20">
-          <h1 className="mb-6 text-4xl leading-tight font-bold tracking-tight sm:text-5xl lg:text-6xl">
-            <span
-              className={cn(
-                "text-7xl font-normal tracking-tight text-red-500 font-instrument-serif",
+    <div className="bg-background text-foreground relative min-h-full w-full overflow-hidden antialiased">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="from-primary/15 via-background to-background absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))]"></div>
+        <div className="bg-primary/10 absolute -top-24 right-[-10%] h-[420px] w-[420px] rounded-full blur-3xl"></div>
+        <div className="bg-primary/5 absolute -bottom-24 left-[-10%] h-[360px] w-[360px] rounded-full blur-3xl"></div>
+      </div>
 
-              )}>
-              Choose Your
-            </span>
-            <br />
-            <span
-              className={cn(
-                "text-8xl font-normal tracking-tight text-black font-instrument-serif",
-
-              )}>
-              Creative Journey
-            </span>
+      <section className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-24 lg:px-8">
+        <div className="mx-auto mb-12 max-w-3xl text-center sm:mb-16">
+          <p className="text-primary text-xs font-semibold uppercase tracking-[0.3em]">
+            Pricing
+          </p>
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-balance sm:text-4xl md:text-5xl lg:text-6xl">
+            Choose Your <span className="text-primary">Creative Journey</span>
           </h1>
-          <p className="mr-auto ml-auto max-w-3xl text-base text-neutral-600 sm:text-lg">
+          <p className="text-muted-foreground mx-auto mt-4 max-w-2xl text-base sm:text-lg">
             From indie creators to enterprise teams, we&apos;ve crafted the
             perfect plan for every stage of your design evolution
           </p>
         </div>
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-8 xl:grid-cols-3">
-          <article className="relative flex flex-col rounded-3xl border-2 border-neutral-200 bg-white pt-8 pr-8 pb-8 pl-8 transition-all duration-300 hover:border-red-500 lg:p-10">
+          <article className="relative flex flex-col rounded-3xl border border-border/50 bg-background/70 p-8 shadow-lg shadow-black/5 backdrop-blur-sm transition-all duration-300 hover:border-primary/50 hover:shadow-primary/10 lg:p-10">
             <div className="mb-8 flex items-start justify-between">
               <div className="flex items-center gap-2">
                 <svg
@@ -43,30 +36,34 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="palette"
-                  className="lucide lucide-palette h-5 w-5 text-red-500">
+                  className="lucide lucide-palette h-5 w-5 text-primary"
+                >
                   <path d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"></path>
                   <circle
                     cx="13.5"
                     cy="6.5"
                     r=".5"
-                    fill="currentColor"></circle>
+                    fill="currentColor"
+                  ></circle>
                   <circle
                     cx="17.5"
                     cy="10.5"
                     r=".5"
-                    fill="currentColor"></circle>
+                    fill="currentColor"
+                  ></circle>
                   <circle
                     cx="6.5"
                     cy="12.5"
                     r=".5"
-                    fill="currentColor"></circle>
+                    fill="currentColor"
+                  ></circle>
                   <circle cx="8.5" cy="7.5" r=".5" fill="currentColor"></circle>
                 </svg>
-                <span className="text-sm font-semibold tracking-wide text-neutral-500 uppercase">
+                <span className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">
                   Creative
                 </span>
               </div>
-              <span className="rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-medium text-red-600 uppercase">
+              <span className="border-primary/20 bg-primary/10 text-primary rounded-full border px-3 py-1 text-xs font-medium uppercase">
                 Perfect Start
               </span>
             </div>
@@ -75,7 +72,7 @@ export default function DesignerPricing() {
               <h2 className="mb-3 text-2xl leading-tight font-medium lg:text-2xl">
                 Individual Creators
               </h2>
-              <p className="text-sm text-neutral-600">
+              <p className="text-muted-foreground text-sm">
                 Everything you need to launch your creative projects
               </p>
             </div>
@@ -85,15 +82,15 @@ export default function DesignerPricing() {
                 <span className="text-4xl font-bold tracking-tight lg:text-5xl">
                   ₹999
                 </span>
-                <span className="mb-1 text-neutral-500">/event</span>
+                <span className="text-muted-foreground mb-1">/event</span>
               </div>
-              <p className="text-xs text-neutral-500">
-                Billed  • Cancel anytime
+              <p className="text-muted-foreground text-xs">
+                Billed • Cancel anytime
               </p>
             </div>
 
             <div className="mb-8 flex flex-col gap-3">
-              <button className="w-full rounded-full bg-red-500 px-6 py-3 text-sm font-semibold text-white transition-all duration-200 hover:bg-red-600">
+              <button className="bg-primary text-primary-foreground w-full rounded-full px-6 py-3 text-sm font-semibold shadow-sm shadow-primary/20 transition-all duration-200 hover:bg-primary/90">
                 Start Creating
               </button>
               {/* <button className="w-full rounded-full border-2 border-black px-6 py-3 text-sm font-medium text-black transition-all duration-200 hover:bg-black hover:text-white">
@@ -101,7 +98,7 @@ export default function DesignerPricing() {
               </button> */}
             </div>
 
-            <hr className="mb-8 border-neutral-200" />
+            <hr className="border-border/50 mb-8" />
 
             <ul className="space-y-4 text-sm">
               <li className="flex items-start gap-3">
@@ -116,7 +113,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -136,7 +134,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -156,7 +155,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -176,7 +176,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -187,9 +188,9 @@ export default function DesignerPricing() {
             </ul>
           </article>
 
-          <article className="relative z-10 flex scale-105 flex-col rounded-3xl border-2 border-black bg-black p-8 text-white transition-all duration-300 lg:scale-110 lg:p-10">
+          <article className="relative z-10 flex flex-col rounded-3xl border border-primary/40 bg-primary/10 p-8 shadow-xl shadow-primary/10 backdrop-blur-sm transition-all duration-300 lg:scale-105 lg:p-10">
             <div className="absolute -top-4 left-1/2 -translate-x-1/2 transform">
-              <div className="rounded-full bg-red-500 px-4 py-2 text-xs font-bold text-white uppercase">
+              <div className="bg-primary text-primary-foreground rounded-full px-4 py-2 text-xs font-bold uppercase">
                 Most Popular
               </div>
             </div>
@@ -207,13 +208,14 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="rocket"
-                  className="lucide lucide-rocket h-5 w-5 text-red-500">
+                  className="lucide lucide-rocket h-5 w-5 text-primary"
+                >
                   <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"></path>
                   <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"></path>
                   <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"></path>
                   <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"></path>
                 </svg>
-                <span className="text-sm font-semibold tracking-wide text-neutral-400 uppercase">
+                <span className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">
                   Professional
                 </span>
               </div>
@@ -223,7 +225,7 @@ export default function DesignerPricing() {
               <h2 className="mb-3 text-2xl leading-tight font-medium lg:text-2xl">
                 Growing Businesses
               </h2>
-              <p className="text-sm text-neutral-300">
+              <p className="text-muted-foreground text-sm">
                 Scale your brand with comprehensive design systems
               </p>
             </div>
@@ -233,15 +235,15 @@ export default function DesignerPricing() {
                 <span className="text-4xl font-bold tracking-tight lg:text-5xl">
                   ₹1999
                 </span>
-                <span className="mb-1 text-neutral-400">/event</span>
+                <span className="text-muted-foreground mb-1">/event</span>
               </div>
-              <p className="text-xs text-neutral-400">
+              <p className="text-muted-foreground text-xs">
                 Billed • Cancel anytime
               </p>
             </div>
 
             <div className="mb-8 flex flex-col gap-3">
-              <button className="w-full rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-all duration-200 hover:bg-neutral-100">
+              <button className="bg-foreground text-background w-full rounded-full px-6 py-3 text-sm font-semibold shadow-sm shadow-black/20 transition-all duration-200 hover:bg-foreground/90">
                 Scale Your Brand
               </button>
               {/* <button className="w-full rounded-full border-2 border-white px-6 py-3 text-sm font-medium text-white transition-all duration-200 hover:bg-white hover:text-black">
@@ -249,7 +251,7 @@ export default function DesignerPricing() {
               </button> */}
             </div>
 
-            <hr className="mb-8 border-neutral-700" />
+            <hr className="border-border/50 mb-8" />
 
             <ul className="space-y-4 text-sm">
               <li className="flex items-start gap-3">
@@ -264,7 +266,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -285,7 +288,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -305,7 +309,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -325,7 +330,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -346,7 +352,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -357,7 +364,7 @@ export default function DesignerPricing() {
             </ul>
           </article>
 
-          <article className="relative flex flex-col rounded-3xl border-2 border-neutral-200 bg-white pt-8 pr-8 pb-8 pl-8 transition-all duration-300 hover:border-red-500 lg:col-span-2 lg:p-10 xl:col-span-1">
+          <article className="relative flex flex-col rounded-3xl border border-border/50 bg-background/70 p-8 shadow-lg shadow-black/5 backdrop-blur-sm transition-all duration-300 hover:border-primary/50 hover:shadow-primary/10 lg:col-span-2 lg:p-10 xl:col-span-1">
             <div className="mb-8 flex items-start justify-between">
               <div className="flex items-center gap-2">
                 <svg
@@ -371,7 +378,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="building-2"
-                  className="lucide lucide-building-2 h-5 w-5 text-red-500">
+                  className="lucide lucide-building-2 h-5 w-5 text-primary"
+                >
                   <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"></path>
                   <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"></path>
                   <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"></path>
@@ -380,11 +388,11 @@ export default function DesignerPricing() {
                   <path d="M10 14h4"></path>
                   <path d="M10 18h4"></path>
                 </svg>
-                <span className="text-sm font-semibold tracking-wide text-neutral-500 uppercase">
+                <span className="text-muted-foreground text-sm font-semibold tracking-wide uppercase">
                   Enterprise
                 </span>
               </div>
-              <span className="rounded-full border border-neutral-300 bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-700 uppercase">
+              <span className="border-border/50 bg-muted/50 text-muted-foreground rounded-full border px-3 py-1 text-xs font-medium uppercase">
                 Custom
               </span>
             </div>
@@ -393,24 +401,24 @@ export default function DesignerPricing() {
               <h2 className="mb-3 text-2xl leading-tight font-medium lg:text-2xl">
                 Large Teams
               </h2>
-              <p className="text-sm text-neutral-600">
+              <p className="text-muted-foreground text-sm">
                 Dedicated design team with unlimited creative capacity
               </p>
             </div>
 
             <div className="mb-8">
               <div className="mb-2 flex items-end gap-2">
-                <span className="text-4xl font-bold tracking-tight text-black lg:text-5xl">
+                <span className="text-4xl font-bold tracking-tight lg:text-5xl">
                   Custom
                 </span>
               </div>
-              <p className="text-xs text-neutral-500">
+              <p className="text-muted-foreground text-xs">
                 Tailored pricing based on your needs
               </p>
             </div>
 
             <div className="mb-8 flex flex-col gap-3">
-              <button className="w-full rounded-full bg-black px-6 py-3 text-sm font-semibold text-white transition-all duration-200 hover:bg-neutral-800">
+              <button className="bg-foreground text-background w-full rounded-full px-6 py-3 text-sm font-semibold shadow-sm shadow-black/20 transition-all duration-200 hover:bg-foreground/90">
                 Get Custom Quote
               </button>
               {/* <button className="w-full rounded-full border-2 border-black px-6 py-3 text-sm font-medium text-black transition-all duration-200 hover:bg-black hover:text-white">
@@ -418,7 +426,7 @@ export default function DesignerPricing() {
               </button> */}
             </div>
 
-            <hr className="mb-8 border-neutral-200" />
+            <hr className="border-border/50 mb-8" />
 
             <ul className="space-y-4 text-sm">
               <li className="flex items-start gap-3">
@@ -433,7 +441,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -453,7 +462,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -473,7 +483,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -493,7 +504,8 @@ export default function DesignerPricing() {
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   data-lucide="check-circle"
-                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-red-500">
+                  className="lucide lucide-check-circle mt-0.5 h-4 w-4 flex-shrink-0 text-primary"
+                >
                   <path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
                   <path d="m9 11 3 3L22 4"></path>
                 </svg>
@@ -506,10 +518,10 @@ export default function DesignerPricing() {
         </div>
 
         <div className="mt-16 text-center sm:mt-20">
-          <p className="mb-8 text-sm text-neutral-500">
+          <p className="text-muted-foreground mb-8 text-sm">
             Trusted by 2,500+ creative professionals worldwide
           </p>
-          <div className="flex items-center justify-center gap-8 opacity-60">
+          <div className="text-muted-foreground flex items-center justify-center gap-8 opacity-70">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"
@@ -521,7 +533,8 @@ export default function DesignerPricing() {
               stroke-linecap="round"
               stroke-linejoin="round"
               data-lucide="shield-check"
-              className="lucide lucide-shield-check h-6 w-6">
+              className="lucide lucide-shield-check h-6 w-6"
+            >
               <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"></path>
               <path d="m9 12 2 2 4-4"></path>
             </svg>
@@ -537,7 +550,8 @@ export default function DesignerPricing() {
               stroke-linecap="round"
               stroke-linejoin="round"
               data-lucide="clock"
-              className="lucide lucide-clock h-6 w-6">
+              className="lucide lucide-clock h-6 w-6"
+            >
               <circle cx="12" cy="12" r="10"></circle>
               <polyline points="12 6 12 12 16 14"></polyline>
             </svg>
@@ -553,7 +567,8 @@ export default function DesignerPricing() {
               stroke-linecap="round"
               stroke-linejoin="round"
               data-lucide="refresh-cw"
-              className="lucide lucide-refresh-cw h-6 w-6">
+              className="lucide lucide-refresh-cw h-6 w-6"
+            >
               <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"></path>
               <path d="M21 3v5h-5"></path>
               <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"></path>

--- a/Frontendd/src/components/mvpblocks/gradient-hero.jsx
+++ b/Frontendd/src/components/mvpblocks/gradient-hero.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { motion } from 'framer-motion';
-import { ArrowRight, ChevronRight, Github } from 'lucide-react';
-import { Button } from '../ui/button.jsx';
-import { Link } from 'react-router-dom';
+import React from "react";
+import { motion } from "framer-motion";
+import { ArrowRight, ChevronRight, Github } from "lucide-react";
+import { Button } from "../ui/button.jsx";
+import { Link } from "react-router-dom";
 
 export default function GradientHero() {
   return (
@@ -24,7 +24,6 @@ export default function GradientHero() {
             className="mx-auto mb-6 flex justify-center"
           >
             <div className="border-border bg-background/80 inline-flex items-center rounded-full border px-3 py-1 text-sm backdrop-blur-sm shadow-lg">
-
               <span className="text-muted-foreground">
                 Powering communities & organizations to host events effortlessly
               </span>
@@ -39,7 +38,7 @@ export default function GradientHero() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="bg-gradient-to-b from-black via-zinc-800 to-zinc-500 bg-clip-text text-center text-4xl tracking-tighter text-balance text-transparent sm:text-5xl md:text-6xl lg:text-7xl"
           >
-           Powering Communities to Run Events Smarter
+            Powering Communities to Run Events Smarter
           </motion.h1>
 
           {/* Description */}
@@ -49,8 +48,10 @@ export default function GradientHero() {
             transition={{ duration: 0.5, delay: 0.2 }}
             className="text-muted-foreground mx-auto mt-6 max-w-2xl text-center text-lg"
           >
-            A modern event management platform designed to help organizations plan, manage, and host impactful events with ease. 
-            Trusted by communities like GDG Jalandhar, AWS Cloud Clubs, Coding Ninjas, and more.
+            A modern event management platform designed to help organizations
+            plan, manage, and host impactful events with ease. Trusted by
+            communities like GDG Jalandhar, AWS Cloud Clubs, Coding Ninjas, and
+            more.
           </motion.p>
 
           {/* CTA Buttons */}
@@ -62,16 +63,15 @@ export default function GradientHero() {
           >
             <Button
               size="lg"
-              className="group bg-primary text-primary-foreground hover:shadow-primary/30 relative overflow-hidden rounded-full px-6 shadow-lg transition-all duration-300"
+              className="group relative overflow-hidden rounded-full px-6 shadow-lg shadow-primary/30 ring-2 ring-primary/20 ring-offset-2 ring-offset-background bg-primary text-primary-foreground transition-all duration-300 hover:shadow-primary/40 hover:ring-primary/40"
               asChild
             >
               <Link to="/signup">
-                <span className="from-primary via-primary/90 to-primary/80 absolute inset-0 z-0 bg-gradient-to-r opacity-0 transition-opacity duration-300 group-hover:opacity-100"></span>
+                <span className="from-primary/80 via-primary to-primary/90 absolute inset-0 z-0 bg-gradient-to-r opacity-40 transition-opacity duration-300 group-hover:opacity-70"></span>
                 <span className="relative z-10 flex items-center">
                   Get Started
                   <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
                 </span>
-                <span className="from-primary via-primary/90 to-primary/80 absolute inset-0 z-0 bg-gradient-to-r opacity-0 transition-opacity duration-300 group-hover:opacity-100"></span>
               </Link>
             </Button>
 
@@ -92,7 +92,7 @@ export default function GradientHero() {
             transition={{
               duration: 0.8,
               delay: 0.5,
-              type: 'spring',
+              type: "spring",
               stiffness: 50,
             }}
             className="relative mx-auto mt-16 max-w-4xl"


### PR DESCRIPTION
# fix: align pricing page with site theme

## 📝 Description

Improved the Pricing page typography, colors, and card styling to align with the existing website theme and improve UI consistency.

### Changes Made

* Updated typography styling for better readability
* Removed mismatched serif and oversized headings
* Replaced hard-coded red/black colors with theme-based styles
* Improved pricing card spacing and visual consistency
* Aligned the Pricing page design with the rest of the application

## 🔗 Related Issue

Closes #122

## 🧪 How to Test

1. cd Frontendd
2. npm install
3. npm run dev
4. Open `/pricing`
5. Verify typography, colors, and card styling match the overall site theme

## ✅ Contributor Checklist

* [x] I am contributing under GSSoC
* [x] My code follows the project's existing style
* [x] I have tested my changes locally
* [x] I have linked the related issue above
* [x] My PR title follows Conventional Commits format
* [x] I used a feature branch (not `main`)
* [x] I have NOT used AI tools to write the core logic without disclosure
