### PR TITLE
fix: add character limit with live counter on event description field…

### DIFF
--- a/Frontendd/src/pages/dashboard/CreateEvent.jsx
+++ b/Frontendd/src/pages/dashboard/CreateEvent.jsx
@@ -106,17 +106,28 @@ export default function CreateEvent() {
                         </div>
 
                         <div>
-                            <Label htmlFor="description">Description</Label>
-                            <Textarea
-                                id="description"
-                                name="description"
-                                className="mt-2"
-                                placeholder="Tell people what your event is about..."
-                                rows={5}
-                                required
-                                onChange={handleChange}
-                            />
-                        </div>
+    <Label htmlFor="description">Description</Label>
+    <Textarea
+        id="description"
+        name="description"
+        className="mt-2"
+        placeholder="Tell people what your event is about..."
+        rows={5}
+        required
+        maxLength={500}
+        onChange={handleChange}
+    />
+    <div className="flex justify-end mt-1">
+        <span className={`text-xs font-medium ${
+            formData.description.length > 450
+                ? 'text-red-500'
+                : 'text-muted-foreground'
+        }`}>
+            {formData.description.length} / 500
+            {formData.description.length > 450 ? ' ❌' : ' ✅'}
+        </span>
+    </div>
+</div>
 
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                             <div>
@@ -201,9 +212,13 @@ export default function CreateEvent() {
                     </div>
 
                     <div className="flex justify-end pt-6">
-                        <Button type="submit" className="bg-rose-500 hover:bg-rose-600 text-white min-w-[150px]" disabled={loading}>
-                            {loading ? 'Creating...' : 'Create Event'}
-                        </Button>
+                        <Button 
+    type="submit" 
+    className="bg-rose-500 hover:bg-rose-600 text-white min-w-[150px]" 
+    disabled={loading || formData.description.length > 500}
+>
+    {loading ? 'Creating...' : 'Create Event'}
+</Button>
                     </div>
                 </motion.form>
             </div>


### PR DESCRIPTION
##  PR Summary
Added a live character counter with a 500-character limit on the event description field in the Create Event form, giving organizers real-time feedback as they type.

---

##  Related Issue
Closes #126

---

## PR Type
* [✓] Bug Fix
* [✓] New Feature / Enhancement
* [ ]Documentation
* [ ]Translation (i18n)
* [✓] UI / UX Improvement
* [ ]DevOps / CI-CD
* [ ]ML / AI Feature
* [ ] Security Fix
* [ ] Refactor / Code Quality

---

## What Was Done
* Added `maxLength={500}` to the description textarea (hard browser-level limit)
* Added live character counter below the textarea showing `{count} / 500`
* Counter turns red when characters exceed 450 (warning zone) with ❌ indicator
* Counter shows ✅ when within the limit
* Submit button is disabled if description exceeds 500 characters
* No new libraries used — pure React state management

---

## 📸 Screenshots / Demo
**Counter within limit:**
> 240 / 500 ✅ 

**Counter in warning zone:**
> 460 / 500 ❌

---

##  Contributor Checklist
* [✓] My PR has a linked issue (see above)
* [✓] I have pulled the latest `main` and rebased/merged before this PR
* [✓] I ran `npm run dev` — no build errors
* [✓] I have performed a self-review of my own code

---
##  Testing Steps

1. Clone the repo and run `npm run dev` in the `Frontendd` folder
2. Log in as an organizer account
3. Navigate to Create Event page
4. Click on the Description field and start typing
5. Observe the live counter below the textarea (e.g. `45 / 500 ✅`)
6. Type until 450+ characters — counter should turn red and show ❌
7. Verify the Create Event button is disabled when over 500 characters
8. Verify the button re-enables when back within the limit

## GSSoC 2026
* [✓] I am a GSSoC 2026 participant