### PR TITLE
fix: add close (X) button to SignIn and SignUp pages

### DIFF
--- a/Frontendd/src/pages/SignIn.jsx
+++ b/Frontendd/src/pages/SignIn.jsx
@@ -64,6 +64,13 @@ export default function SignIn() {
                             backgroundSize: '24px 24px'
                         }}
                     >
+                      {/* Close Button */}
+                        <button
+                           onClick={() => navigate(-1)}
+                           className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-zinc-800 hover:bg-zinc-700 text-gray-400 hover:text-white transition-all duration-200 z-20"
+                           type="button">
+                           ✕
+                        </button>
                         {/* Title */}
                         <div className="text-center mb-10 relative z-10">
                             <h1 className="text-3xl font-bold text-gray-900 tracking-tight">

--- a/Frontendd/src/pages/SignUp.jsx
+++ b/Frontendd/src/pages/SignUp.jsx
@@ -151,6 +151,15 @@ export default function SignUp() {
                             backgroundSize: '24px 24px'
                         }}
                     >
+                        {/* Close Button */}
+                        <button
+                           onClick={() => navigate(-1)}
+                           className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-zinc-800 hover:bg-zinc-700 text-gray-400 hover:text-white transition-all duration-200 z-20"
+                           type="button">
+                            ✕
+                        </button>
+
+                        
                         {/* Title */}
                         <div className="text-center mb-10 relative z-10">
                             <h1 className="text-3xl font-bold text-gray-900 tracking-tight">


### PR DESCRIPTION
## Changes Made
- Added a close (X) button to SignIn page
- Added a close (X) button to SignUp page
- Button navigates user back to previous page on click
- Button is positioned at top-right corner of the form card

## Issue
Closes #128 

## How to Test
1. Run the project locally
2. Go to /login page
3. Verify X button appears at top-right corner
4. Click X button — should navigate back
5. Go to /signup page
6. Verify same X button is present

## Screenshots
### After:
[ SignIn page screenshot with X button]

<img width="1637" height="872" alt="Screenshot (300)" src="https://github.com/user-attachments/assets/42a7579d-bf06-409a-a42d-9bc73404aaf4" />


[ SignUp page screenshot with X button] 

<img width="1578" height="881" alt="Screenshot (301)" src="https://github.com/user-attachments/assets/9ff391d0-1269-4aac-bfb4-7f0fec52aa2d" />

