### PR TITLE
fix: disable copy-paste in confirm password fields

### DIFF
--- a/Frontendd/src/pages/SignUp.jsx
+++ b/Frontendd/src/pages/SignUp.jsx
@@ -268,6 +268,10 @@ export default function SignUp() {
                                         required
                                         value={formData.confirmPassword}
                                         onChange={handleChange}
+                                        onPaste={(e) => {
+                                            e.preventDefault(); // Blocks the paste action
+                                            toast.error("Pasting is not allowed. Please type your password manually for security."); // Shows the notification
+                                        }}
                                         className={`w-full bg-white/50 border rounded-lg px-4 py-3 text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#e63946] focus:border-transparent transition-all duration-300 pr-10 text-base backdrop-blur-sm shadow-sm ${errors.confirmPassword ? 'border-red-500' : 'border-white/50'}`}
                                         placeholder="••••••••"
                                     />


### PR DESCRIPTION
## Description
 Closes #63 

This PR solves the password security issue by disabling the `onPaste` event in the "Confirm Password" fields. 

### The Changes
* Included onPaste event in the `SignUp.jsx` component.
* Added `e.preventDefault()` to block paste action.
* Verified that existing logic remain unaffected.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
