### PR TITLE
fix: remove duplicate merged code in registerForEvent and cancelRegis…

### DIFF
--- a/backend/src/controllers/registrationController.js
+++ b/backend/src/controllers/registrationController.js
@@ -14,41 +14,8 @@ import { emitRegistrationCount } from '../services/socket.js';
 export const registerForEvent = async (req, res) => {
   try {
     const event = await Event.findById(req.params.id);
-    if (!event || event.status !== 'approved') return res.status(400).json({ message: 'Event not available' });
-    const payload = JSON.stringify({ userId: req.user.id, eventId: event._id, at: Date.now() });
-    const qrCodeDataUrl = await generateQRCodeDataUrl(payload);
-
-    // Current implementation includes : 
-    // Checks for an existing cancelled registration
-    // Reactivating the existing registration instead of inserting a new record
-    // Capacity validation on event registration
-    // Keeps the audit trail intact while avoiding unique index conflicts
-
-    // Check active registration
-    const activeRegistrations = await Registration.countDocuments({
-      event: req.params.id,
-      status: { $ne: "cancelled" },
-    });
-
-    // Capacity validation
-    if (activeRegistrations >= event.capacity && event.capacity > 0) {
-      return res.status(400).json({
-        message: "Event is fully booked"
-      })
-    }
-
-    // To reinitiate the existing registered event
-    const existingRegistration = await Registration.findOne({ user: req.user.id, event: req.params.id });
-
-    if (existingRegistration) {
-      if (existingRegistration.status === "cancelled") {
-        existingRegistration.status = 'registered';
-      }
-
     if (!event || event.status !== 'approved') {
-      return res.status(400).json({
-        message: 'Event not available',
-      });
+      return res.status(400).json({ message: 'Event not available' });
     }
 
     // Check existing registration
@@ -57,76 +24,40 @@ export const registerForEvent = async (req, res) => {
       event: event._id,
     });
 
-    // Already active
+    // Already active — reject immediately
     if (
       existingRegistration &&
-      ['registered', 'waitlisted', 'attended'].includes(
-        existingRegistration.status
-      )
+      ['registered', 'waitlisted', 'attended'].includes(existingRegistration.status)
     ) {
-      return res.status(400).json({
-        message: 'Already registered or waitlisted',
-      });
+      return res.status(400).json({ message: 'Already registered or waitlisted' });
     }
 
-    // Atomically increment count only if under capacity
+    // Atomically increment count only if under capacity (prevents race conditions)
     const updatedEvent = await Event.findOneAndUpdate(
       {
         _id: event._id,
         status: 'approved',
-        $expr: {
-          $lt: ['$registeredCount', '$capacity'],
-        },
+        $expr: { $lt: ['$registeredCount', '$capacity'] },
       },
-      {
-        $inc: {
-          registeredCount: 1,
-        },
-      },
-      {
-        new: true,
-      }
+      { $inc: { registeredCount: 1 } },
+      { new: true }
     );
 
-      return res.status(201).json({
-        registration: existingRegistration,
-      })
-    }
-
-    else {
-      const reg = await Registration.create({ user: req.user.id, event: event._id, qrCodeDataUrl });
-      try {
-        await sendEmail({ to: req.user.email, subject: `Registered: ${event.title}`, html: `<p>You are registered for ${event.title}.</p>` });
-      } catch (_) { }
     // Event is full — reject immediately, no registration created
     if (!updatedEvent) {
-      return res.status(400).json({
-        message: 'Event is full',
-      });
+      return res.status(400).json({ message: 'Event is full' });
     }
 
-    const payload = JSON.stringify({
-      userId: req.user.id,
-      eventId: event._id,
-      at: Date.now(),
-    });
-
-    const qrCodeDataUrl =
-      await generateQRCodeDataUrl(payload);
+    const payload = JSON.stringify({ userId: req.user.id, eventId: event._id, at: Date.now() });
+    const qrCodeDataUrl = await generateQRCodeDataUrl(payload);
 
     let registration;
 
-    // Reuse cancelled registration
-    if (
-      existingRegistration &&
-      existingRegistration.status === 'cancelled'
-    ) {
+    // Reuse cancelled registration if one exists
+    if (existingRegistration && existingRegistration.status === 'cancelled') {
       existingRegistration.status = 'registered';
-      existingRegistration.qrCodeDataUrl =
-        qrCodeDataUrl;
-
-      registration =
-        await existingRegistration.save();
+      existingRegistration.qrCodeDataUrl = qrCodeDataUrl;
+      registration = await existingRegistration.save();
     } else {
       try {
         registration = await Registration.create({
@@ -137,32 +68,18 @@ export const registerForEvent = async (req, res) => {
         });
       } catch (dupErr) {
         if (dupErr.code === 11000) {
-          await Event.findByIdAndUpdate(
-            event._id,
-            {
-              $inc: {
-                registeredCount: -1,
-              },
-            }
-          );
-
-          return res.status(400).json({
-            message:
-              'Already registered or waitlisted',
-          });
+          // Roll back the count increment on duplicate key error
+          await Event.findByIdAndUpdate(event._id, { $inc: { registeredCount: -1 } });
+          return res.status(400).json({ message: 'Already registered or waitlisted' });
         }
-
         throw dupErr;
       }
     }
 
+    // Emit real-time registration count update
+    emitRegistrationCount(updatedEvent._id, updatedEvent.registeredCount);
 
-    // Send email
-    emitRegistrationCount(
-      updatedEvent._id,
-      updatedEvent.registeredCount,
-    );
-
+    // Send confirmation email (non-critical — swallow errors)
     try {
       await sendEmail({
         to: req.user.email,
@@ -171,333 +88,201 @@ export const registerForEvent = async (req, res) => {
       });
     } catch (_) {}
 
-    res.status(201).json({
-      registration,
-      message: 'Successfully registered',
-    });
+    res.status(201).json({ registration, message: 'Successfully registered' });
   } catch (err) {
     console.error('ERROR:', err);
-
-    res.status(500).json({
-      message: err.message,
-    });
+    res.status(500).json({ message: err.message });
   }
 };
 
 // Fetch registrations with waitlist position
-export const myRegistrations = async (
-  req,
-  res
-) => {
+export const myRegistrations = async (req, res) => {
   try {
-    const regs = await Registration.find({
-      user: req.user.id,
-    }).populate('event');
+    const regs = await Registration.find({ user: req.user.id }).populate('event');
 
-    const registrationsWithPosition =
-      await Promise.all(
-        regs.map(async (reg) => {
-          let waitlistPosition = null;
+    const registrationsWithPosition = await Promise.all(
+      regs.map(async (reg) => {
+        let waitlistPosition = null;
 
-          if (reg.status === 'waitlisted') {
-            const peopleAhead =
-              await Registration.countDocuments({
-                event: reg.event._id,
-                status: 'waitlisted',
-                createdAt: {
-                  $lt: reg.createdAt,
-                },
-              });
+        if (reg.status === 'waitlisted') {
+          const peopleAhead = await Registration.countDocuments({
+            event: reg.event._id,
+            status: 'waitlisted',
+            createdAt: { $lt: reg.createdAt },
+          });
+          waitlistPosition = peopleAhead + 1;
+        }
 
-            waitlistPosition =
-              peopleAhead + 1;
-          }
+        return { ...reg.toObject(), waitlistPosition };
+      })
+    );
 
-          return {
-            ...reg.toObject(),
-            waitlistPosition,
-          };
-        })
-      );
-
-    res.json({
-      registrations:
-        registrationsWithPosition,
-    });
+    res.json({ registrations: registrationsWithPosition });
   } catch (err) {
     console.error('ERROR:', err);
-
-    res.status(500).json({
-      message: err.message,
-    });
+    res.status(500).json({ message: err.message });
   }
 };
 
 // Get participants for organizer/admin
-export const participantsForEvent =
-  async (req, res) => {
-    try {
-      const regs = await Registration.find({
-        event: req.params.id,
-      }).populate('user', 'name email');
-
-      res.json({
-        participants: regs,
-      });
-    } catch (err) {
-      console.error('ERROR:', err);
-
-      res.status(500).json({
-        message: err.message,
-      });
-    }
-  };
+export const participantsForEvent = async (req, res) => {
+  try {
+    const regs = await Registration.find({ event: req.params.id }).populate('user', 'name email');
+    res.json({ participants: regs });
+  } catch (err) {
+    console.error('ERROR:', err);
+    res.status(500).json({ message: err.message });
+  }
+};
 
 // Secure check-in handler
-export const checkInParticipant =
-  async (req, res) => {
-    try {
-      if (!req.user) {
-        return res.status(401).json({
-          message:
-            'Unauthorized: user not authenticated',
-        });
-      }
-
-      if (!req.body || !req.body.userId) {
-        return res.status(400).json({
-          message:
-            'Bad Request: userId is required',
-        });
-      }
-
-      const validStatuses = [
-        'attended',
-        'cancelled',
-        'no-show',
-      ];
-
-      const status = (
-        req.body.status || 'attended'
-      )
-        .toString()
-        .trim()
-        .toLowerCase();
-
-      if (!validStatuses.includes(status)) {
-        return res.status(400).json({
-          message: 'Invalid status',
-        });
-      }
-
-      const event = await Event.findById(
-        req.params.id
-      ).select('organizer');
-
-      if (!event) {
-        return res.status(404).json({
-          message: 'Event not found',
-        });
-      }
-
-      if (
-        req.user.role !== 'admin' &&
-        event.organizer.toString() !==
-          req.user.id
-      ) {
-        return res.status(403).json({
-          message:
-            'Forbidden: not organizer',
-        });
-      }
-
-      const registration = await Registration.findOne({
-        user: req.body.userId,
-        event: req.params.id,
-      });
-
-      if (!registration) {
-        return res.status(404).json({
-          message: 'Registration not found',
-        });
-      }
-
-      if (status === 'attended' && registration.status === 'attended') {
-        return res.status(400).json({
-          message: 'Attendee already checked in',
-        });
-      }
-
-      registration.status = status;
-      if (status === 'attended') {
-        registration.checkedInAt = new Date();
-      } else {
-        registration.checkedInAt = undefined;
-      }
-      await registration.save();
-
-      // Promote waitlisted user
-      if (status === 'cancelled') {
-        await promoteFromWaitlist(
-          req.params.id
-        );
-      }
-
-      const attendee =
-        await User.findById(
-          req.body.userId
-        );
-
-      res.status(200).json({
-        registration,
-        attendeeName:
-          attendee?.name || 'Attendee',
-      });
-    } catch (err) {
-      console.error('ERROR:', err);
-
-      res.status(500).json({
-        message: err.message,
-      });
+export const checkInParticipant = async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ message: 'Unauthorized: user not authenticated' });
     }
-  };
 
-// Export CSV
-export const exportParticipantsCsv =
-  async (req, res) => {
-    try {
-      const regs = await Registration.find({
-        event: req.params.id,
-      }).populate('user', 'name email');
-
-      const rows = regs.map((r) => ({
-        name: r.user?.name || '',
-        email: r.user?.email || '',
-        status: r.status,
-        registeredAt: r.createdAt,
-      }));
-
-      const filePath = path.join(
-        process.cwd(),
-        `participants-${req.params.id}.csv`
-      );
-
-      const csvWriter =
-        createObjectCsvWriter({
-          path: filePath,
-          header: [
-            {
-              id: 'name',
-              title: 'Name',
-            },
-            {
-              id: 'email',
-              title: 'Email',
-            },
-            {
-              id: 'status',
-              title: 'Status',
-            },
-            {
-              id: 'registeredAt',
-              title: 'Registered At',
-            },
-          ],
-        });
-
-      await csvWriter.writeRecords(rows);
-
-      res.download(filePath);
-    } catch (err) {
-      console.error('ERROR:', err);
-
-      res.status(500).json({
-        message: err.message,
-      });
+    if (!req.body || !req.body.userId) {
+      return res.status(400).json({ message: 'Bad Request: userId is required' });
     }
-  };
 
-// Registration status
-export const checkRegistrationStatus =
-  async (req, res) => {
-    try {
-      const registration =
-        await Registration.findOne({
-          user: req.user.id,
-          event: req.params.id,
-          status: {
-            $ne: 'cancelled',
-          },
-        });
+    const validStatuses = ['attended', 'cancelled', 'no-show'];
+    const status = (req.body.status || 'attended').toString().trim().toLowerCase();
 
-      res.json({
-        isRegistered:
-          registration?.status ===
-          'registered',
-
-        isWaitlisted:
-          registration?.status ===
-          'waitlisted',
-
-        registration,
-      });
-    } catch (err) {
-      console.error('ERROR:', err);
-
-      res.status(500).json({
-        message: err.message,
-      });
+    if (!validStatuses.includes(status)) {
+      return res.status(400).json({ message: 'Invalid status' });
     }
-  };
 
-// Promote waitlisted user
-export const promoteFromWaitlist =
-  async (eventId) => {
-    const nextRegistration =
-      await Registration.findOne({
-        event: eventId,
-        status: 'waitlisted',
-      })
-        .sort({
-          createdAt: 1,
-        })
-        .populate('user')
-        .populate('event');
+    const event = await Event.findById(req.params.id).select('organizer');
+    if (!event) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
 
-    if (!nextRegistration) return;
+    if (req.user.role !== 'admin' && event.organizer.toString() !== req.user.id) {
+      return res.status(403).json({ message: 'Forbidden: not organizer' });
+    }
 
-    const payload = JSON.stringify({
-      userId:
-        nextRegistration.user._id,
-      eventId:
-        nextRegistration.event._id,
-      at: Date.now(),
+    const registration = await Registration.findOne({
+      user: req.body.userId,
+      event: req.params.id,
     });
 
-    const qrCodeDataUrl =
-      await generateQRCodeDataUrl(
-        payload
-      );
+    if (!registration) {
+      return res.status(404).json({ message: 'Registration not found' });
+    }
 
-    nextRegistration.status =
-      'registered';
+    if (status === 'attended' && registration.status === 'attended') {
+      return res.status(400).json({ message: 'Attendee already checked in' });
+    }
 
-    nextRegistration.qrCodeDataUrl =
-      qrCodeDataUrl;
+    registration.status = status;
+    if (status === 'attended') {
+      registration.checkedInAt = new Date();
+    } else {
+      registration.checkedInAt = undefined;
+    }
+    await registration.save();
 
-    await nextRegistration.save();
+    // Promote waitlisted user if cancelled
+    if (status === 'cancelled') {
+      await promoteFromWaitlist(req.params.id);
+    }
 
-    try {
-      await sendEmail({
-        to: nextRegistration.user.email,
-        subject: `Spot Confirmed: ${nextRegistration.event.title}`,
-        html: `
+    const attendee = await User.findById(req.body.userId);
+    res.status(200).json({ registration, attendeeName: attendee?.name || 'Attendee' });
+  } catch (err) {
+    console.error('ERROR:', err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Export CSV
+export const exportParticipantsCsv = async (req, res) => {
+  try {
+    const regs = await Registration.find({ event: req.params.id }).populate('user', 'name email');
+
+    const rows = regs.map((r) => ({
+      name: r.user?.name || '',
+      email: r.user?.email || '',
+      status: r.status,
+      registeredAt: r.createdAt,
+    }));
+
+    const filePath = path.join(process.cwd(), `participants-${req.params.id}.csv`);
+
+    const csvWriter = createObjectCsvWriter({
+      path: filePath,
+      header: [
+        { id: 'name', title: 'Name' },
+        { id: 'email', title: 'Email' },
+        { id: 'status', title: 'Status' },
+        { id: 'registeredAt', title: 'Registered At' },
+      ],
+    });
+
+    await csvWriter.writeRecords(rows);
+    res.download(filePath);
+  } catch (err) {
+    console.error('ERROR:', err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Registration status
+export const checkRegistrationStatus = async (req, res) => {
+  try {
+    const registration = await Registration.findOne({
+      user: req.user.id,
+      event: req.params.id,
+      status: { $ne: 'cancelled' },
+    });
+
+    res.json({
+      isRegistered: registration?.status === 'registered',
+      isWaitlisted: registration?.status === 'waitlisted',
+      registration,
+    });
+  } catch (err) {
+    console.error('ERROR:', err);
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// Promote waitlisted user
+export const promoteFromWaitlist = async (eventId) => {
+  const nextRegistration = await Registration.findOne({
+    event: eventId,
+    status: 'waitlisted',
+  })
+    .sort({ createdAt: 1 })
+    .populate('user')
+    .populate('event');
+
+  if (!nextRegistration) return;
+
+  const payload = JSON.stringify({
+    userId: nextRegistration.user._id,
+    eventId: nextRegistration.event._id,
+    at: Date.now(),
+  });
+
+  const qrCodeDataUrl = await generateQRCodeDataUrl(payload);
+
+  nextRegistration.status = 'registered';
+  nextRegistration.qrCodeDataUrl = qrCodeDataUrl;
+  await nextRegistration.save();
+
+  try {
+    await sendEmail({
+      to: nextRegistration.user.email,
+      subject: `Spot Confirmed: ${nextRegistration.event.title}`,
+      html: `
         <p>You have been promoted from the waitlist.</p>
         <p>Your registration for ${nextRegistration.event.title} is now confirmed.</p>
       `,
-      });
-    } catch (_) {}
-  };
+    });
+  } catch (_) {}
+};
 
 export const cancelRegistration = async (req, res) => {
   // Only the customer who owns the registration can cancel it
@@ -509,113 +294,93 @@ export const cancelRegistration = async (req, res) => {
     const userId = req.user.id;
 
     const registration = await Registration.findById(id)
-      .populate("event")
-      .populate("user");
+      .populate('event')
+      .populate('user');
 
-      const registration =
-        await Registration.findById(
-          id
-        ).populate('event');
+    if (!registration) {
+      return res.status(404).json({ message: 'Registration not found' });
+    }
 
     // Owner check
     if (registration.user._id.toString() !== userId) {
-      return res.status(403).json({
-        message: "Unauthorized",
-      });
+      return res.status(403).json({ message: 'Unauthorized' });
     }
 
-      // Owner check
-      if (
-        registration.user.toString() !==
-        userId
-      ) {
-        return res.status(403).json({
-          message: 'Unauthorized',
-        });
-      }
+    // Already cancelled
+    if (registration.status === 'cancelled') {
+      return res.status(400).json({ message: 'Already cancelled' });
+    }
 
-      // Already cancelled
-      if (
-        registration.status ===
-        'cancelled'
-      ) {
-        return res.status(400).json({
-          message: 'Already cancelled',
-        });
-      }
+    // Past event check
+    const eventDate = new Date(registration.event.date);
+    if (eventDate < new Date()) {
+      return res.status(400).json({ message: 'Cannot cancel past events' });
+    }
 
     let refundData = {
       refundStatus: 'not_applicable',
-      refundAmount: 0
-    }
+      refundAmount: 0,
+    };
 
     // Check if the event is paid or free
     const isPaidEvent = registration.event.price && registration.event.price > 0;
 
     if (isPaidEvent) {
-      // Check if the event is more than 24 hours away (no refunds within 24 hours of event)
       const refundPolicy = calculateRefund(eventDate, registration.event.price);
-
       refundData = {
         refundStatus: refundPolicy.status,
-        refundAmount: refundPolicy.refundAmount
-      }
+        refundAmount: refundPolicy.refundAmount,
+      };
 
       if (refundPolicy.eligible && registration.paymentId) {
         try {
-          // Call Razorpay Refund API with the stored paymentId
-          console.log("Refund API call...")
-          // TODO: Add after #76 merges
-          // Razorpay refund integration
-
+          console.log('Refund API call...');
+          // TODO: Add after #76 merges — Razorpay refund integration
           /*
-          const refund =
-            await razorpay.payments.refund(
-              registration.paymentId,
-              {
-                amount:
-                  refundPolicy.refundAmount * 100,
-              }
-            );
-
+          const refund = await razorpay.payments.refund(registration.paymentId, {
+            amount: refundPolicy.refundAmount * 100,
+          });
           refundData.refundId = refund.id;
-          refundData.refundStatus =
-            refund.status;
+          refundData.refundStatus = refund.status;
           */
 
           // Mock temporary response
-          refundData.refundId =
-            "mock_refund_id";
-          refundData.refundStatus =
-            "pending";
-          refundData.refundedAt =
-            new Date();
+          refundData.refundId = 'mock_refund_id';
+          refundData.refundStatus = 'pending';
+          refundData.refundedAt = new Date();
 
-          // Send a refund confirmation email to the customer
+          // Send refund confirmation email
           try {
-            await sendEmail({ to: req.user.email, subject: `Payment Refund : ${registration.event.title}`, html: `<p>You are refunded for ${registration.event.title} of total Amount : ${refundData.refundAmount}.</p>` });
-          } catch (_) { }
-
+            await sendEmail({
+              to: req.user.email,
+              subject: `Payment Refund : ${registration.event.title}`,
+              html: `<p>You are refunded for ${registration.event.title} of total Amount : ${refundData.refundAmount}.</p>`,
+            });
+          } catch (_) {}
         } catch (refundError) {
+          console.log(refundError);
           return res.status(500).json({
-            message: "Refund processing failed",
+            message: 'Refund processing failed',
             error: refundError.message,
           });
-          console.log(refundError)
         }
       }
     }
 
-    // Save refund details: refundId, refundStatus, refundedAt to the Registration document
+    // Save refund details to the Registration document
     registration.refundId = refundData.refundId || null;
     registration.refundStatus = refundData.refundStatus;
     registration.refundAmount = refundData.refundAmount;
     registration.refundedAt = refundData.refundedAt || null;
 
-
-
-    registration.status = "cancelled";
+    registration.status = 'cancelled';
     await registration.save();
+
+    // Decrease registered count
+    await Event.findByIdAndUpdate(registration.event._id, { $inc: { registeredCount: -1 } });
+
+    // Promote next waitlisted user
+    await promoteFromWaitlist(registration.event._id);
 
     res.status(200).json({
       message: 'Registration cancelled successfully',
@@ -626,7 +391,6 @@ export const cancelRegistration = async (req, res) => {
   }
 };
 
-
 export const checkRefundStatus = async (req, res) => {
   try {
     const { id } = req.params;
@@ -634,172 +398,87 @@ export const checkRefundStatus = async (req, res) => {
 
     const registration = await Registration.findById(id);
 
-    // Registration exists check
     if (!registration) {
-      return res.status(404).json({
-        message: "Registration not found",
-      });
+      return res.status(404).json({ message: 'Registration not found' });
     }
 
     // Owner check
     if (registration.user.toString() !== userId) {
-      return res.status(403).json({
-        message: "Unauthorized",
-      });
+      return res.status(403).json({ message: 'Unauthorized' });
     }
 
     // Refund only applies to cancelled registrations
-    if (registration.status !== "cancelled") {
-      return res.status(400).json({
-        message:
-          "Registration is not cancelled",
-      });
+    if (registration.status !== 'cancelled') {
+      return res.status(400).json({ message: 'Registration is not cancelled' });
     }
 
     // Free event / no payment
     if (!registration.paymentId) {
       return res.status(200).json({
-        refundStatus:
-          "not_applicable",
+        refundStatus: 'not_applicable',
         refundAmount: 0,
         refundedAt: null,
-        message:"No refund for free events",
+        message: 'No refund for free events',
       });
     }
 
     return res.status(200).json({
-      refundStatus:registration.refundStatus,
-      refundAmount:registration.refundAmount,
-      refundedAt:registration.refundedAt,
-      refundId:registration.refundId,
+      refundStatus: registration.refundStatus,
+      refundAmount: registration.refundAmount,
+      refundedAt: registration.refundedAt,
+      refundId: registration.refundId,
     });
-
   } catch (error) {
-    return res.status(500).json({
-      message: error.message,
-    });
+    return res.status(500).json({ message: error.message });
   }
 };
 
 export const checkRefundPolicy = async (req, res) => {
-
   try {
     const { id } = req.params;
-    const userId = req.user.id; // from auth middleware
+    const userId = req.user.id;
 
     const registration = await Registration.findById(id)
-      .populate("event")
-      .populate("user");
+      .populate('event')
+      .populate('user');
 
     if (!registration) {
-      return res.status(404).json({
-        message: "Registration not found",
-      });
+      return res.status(404).json({ message: 'Registration not found' });
     }
-
-    console.log(
-      req.user.id,
-      registration.user.toString()
-    );
 
     // Owner check
     if (registration.user._id.toString() !== userId) {
-      return res.status(403).json({
-        message: "Unauthorized",
-      });
+      return res.status(403).json({ message: 'Unauthorized' });
     }
 
     // Already cancelled
-    if (registration.status === "cancelled") {
-      return res.status(400).json({
-        message: "Already cancelled",
-      });
+    if (registration.status === 'cancelled') {
+      return res.status(400).json({ message: 'Already cancelled' });
     }
 
     // Past event check
     const eventDate = new Date(registration.event.date);
-
     if (eventDate < new Date()) {
-      return res.status(400).json({
-        message: "Cannot cancel past events",
-      });
+      return res.status(400).json({ message: 'Cannot cancel past events' });
     }
 
     let refundData = {
       refundStatus: 'not_applicable',
-      refundAmount: 0
-    }
+      refundAmount: 0,
+    };
 
-    // Check if the event is paid or free
     const isPaidEvent = registration.event.price && registration.event.price > 0;
 
     if (isPaidEvent) {
-      // Check if the event is more than 24 hours away (no refunds within 24 hours of event)
       const refundPolicy = calculateRefund(eventDate, registration.event.price);
-
       refundData = {
         refundStatus: refundPolicy.status,
-        refundAmount: refundPolicy.refundAmount
-      }
-
-      
+        refundAmount: refundPolicy.refundAmount,
+      };
     }
 
-    res.status(200).json({
-      refundData,
-    });
-
-    
-
+    res.status(200).json({ refundData });
   } catch (error) {
-    res.status(500).json({
-      message: error.message,
-    });
+    res.status(500).json({ message: error.message });
   }
 };
-
-
-      // Past event check
-      const eventDate = new Date(
-        registration.event.date
-      );
-
-      if (eventDate < new Date()) {
-        return res.status(400).json({
-          message:
-            'Cannot cancel past events',
-        });
-      }
-
-      registration.status = 'cancelled';
-
-      await registration.save();
-
-      // Decrease registered count
-      await Event.findByIdAndUpdate(
-        registration.event._id,
-        {
-          $inc: {
-            registeredCount: -1,
-          },
-        }
-      );
-
-      // Promote next waitlisted user
-      await promoteFromWaitlist(
-        registration.event._id
-      );
-
-      res.status(200).json({
-        message:
-          'Registration cancelled successfully',
-        registration,
-      });
-    } catch (error) {
-      console.error('ERROR:', error);
-
-      res.status(500).json({
-        message: error.message,
-      });
-    }
-  };


### PR DESCRIPTION
fix: remove duplicate merged code in registerForEvent (closes #281)

Fixes #281

### Changes Made
- Removed broken first implementation with manual capacity check and race condition risk
- Removed dangling else block that caused broken control flow
- Kept only the atomic findOneAndUpdate implementation
- Fixed cancelRegistration, which had the same duplicate merge conflict issue

### What was wrong
Two implementations were merged with an unclosed if/else block, 
making the second (correct) implementation unreachable.

### What was fixed
Only the atomic findOneAndUpdate version is now used, which:
- Prevents race conditions on capacity
- Handles duplicate key errors (err.code === 11000)
- Calls emitRegistrationCount() for real-time updates
- Properly reuses cancelled registrations

### How to Test
1. Start the backend server with `npm run dev`
2. Run `node --check src/controllers/registrationController.js` — should show no errors
3. Attempt to register for a full event — should return "Event is full"
4. Attempt to register twice — should return "Already registered"

Stage 1 is failing due to a deprecated 
Node.js 20 action (actions/github-script@v7) in the workflow 
— this is unrelated to my code changes. Could you update the 
workflow or manually verify Stage 1 so the PR can proceed 
to mentor review? Thanks!