### PR TITLE
fix: remove duplicate merged code in registerForEvent and cancelRegistration

### DIFF
--- a/backend/src/controllers/registrationController.js
+++ b/backend/src/controllers/registrationController.js
@@ -14,36 +14,6 @@ import { emitRegistrationCount } from '../services/socket.js';
 export const registerForEvent = async (req, res) => {
   try {
     const event = await Event.findById(req.params.id);
-    if (!event || event.status !== 'approved') return res.status(400).json({ message: 'Event not available' });
-    const payload = JSON.stringify({ userId: req.user.id, eventId: event._id, at: Date.now() });
-    const qrCodeDataUrl = await generateQRCodeDataUrl(payload);
-
-    // Current implementation includes : 
-    // Checks for an existing cancelled registration
-    // Reactivating the existing registration instead of inserting a new record
-    // Capacity validation on event registration
-    // Keeps the audit trail intact while avoiding unique index conflicts
-
-    // Check active registration
-    const activeRegistrations = await Registration.countDocuments({
-      event: req.params.id,
-      status: { $ne: "cancelled" },
-    });
-
-    // Capacity validation
-    if (activeRegistrations >= event.capacity && event.capacity > 0) {
-      return res.status(400).json({
-        message: "Event is fully booked"
-      })
-    }
-
-    // To reinitiate the existing registered event
-    const existingRegistration = await Registration.findOne({ user: req.user.id, event: req.params.id });
-
-    if (existingRegistration) {
-      if (existingRegistration.status === "cancelled") {
-        existingRegistration.status = 'registered';
-      }
 
     if (!event || event.status !== 'approved') {
       return res.status(400).json({
@@ -88,16 +58,6 @@ export const registerForEvent = async (req, res) => {
       }
     );
 
-      return res.status(201).json({
-        registration: existingRegistration,
-      })
-    }
-
-    else {
-      const reg = await Registration.create({ user: req.user.id, event: event._id, qrCodeDataUrl });
-      try {
-        await sendEmail({ to: req.user.email, subject: `Registered: ${event.title}`, html: `<p>You are registered for ${event.title}.</p>` });
-      } catch (_) { }
     // Event is full — reject immediately, no registration created
     if (!updatedEvent) {
       return res.status(400).json({
@@ -111,8 +71,7 @@ export const registerForEvent = async (req, res) => {
       at: Date.now(),
     });
 
-    const qrCodeDataUrl =
-      await generateQRCodeDataUrl(payload);
+    const qrCodeDataUrl = await generateQRCodeDataUrl(payload);
 
     let registration;
 
@@ -122,11 +81,9 @@ export const registerForEvent = async (req, res) => {
       existingRegistration.status === 'cancelled'
     ) {
       existingRegistration.status = 'registered';
-      existingRegistration.qrCodeDataUrl =
-        qrCodeDataUrl;
+      existingRegistration.qrCodeDataUrl = qrCodeDataUrl;
 
-      registration =
-        await existingRegistration.save();
+      registration = await existingRegistration.save();
     } else {
       try {
         registration = await Registration.create({
@@ -137,18 +94,15 @@ export const registerForEvent = async (req, res) => {
         });
       } catch (dupErr) {
         if (dupErr.code === 11000) {
-          await Event.findByIdAndUpdate(
-            event._id,
-            {
-              $inc: {
-                registeredCount: -1,
-              },
-            }
-          );
+          // Revert increment if duplicate creation occurs
+          await Event.findByIdAndUpdate(event._id, {
+            $inc: {
+              registeredCount: -1,
+            },
+          });
 
           return res.status(400).json({
-            message:
-              'Already registered or waitlisted',
+            message: 'Already registered',
           });
         }
 
@@ -156,28 +110,26 @@ export const registerForEvent = async (req, res) => {
       }
     }
 
+    // Emit live stats update
+    emitRegistrationCount(updatedEvent._id, updatedEvent.registeredCount);
 
-    // Send email
-    emitRegistrationCount(
-      updatedEvent._id,
-      updatedEvent.registeredCount,
-    );
-
+    // Send email (non-blocking)
     try {
       await sendEmail({
         to: req.user.email,
         subject: `Registered: ${event.title}`,
         html: `<p>You are registered for ${event.title}.</p>`,
       });
-    } catch (_) {}
+    } catch (_) {
+      // Ignore email errors to not break registration flow
+    }
 
     res.status(201).json({
       registration,
       message: 'Successfully registered',
     });
   } catch (err) {
-    console.error('ERROR:', err);
-
+    console.error('Registration Error:', err);
     res.status(500).json({
       message: err.message,
     });
@@ -500,128 +452,114 @@ export const promoteFromWaitlist =
   };
 
 export const cancelRegistration = async (req, res) => {
-  // Only the customer who owns the registration can cancel it
-  // Cannot cancel if event.date is in the past
-  // Sets registration.status = 'cancelled'; does not delete the document (for audit trail)
-
   try {
     const { id } = req.params;
     const userId = req.user.id;
 
     const registration = await Registration.findById(id)
-      .populate("event")
-      .populate("user");
+      .populate('event')
+      .populate('user');
 
-      const registration =
-        await Registration.findById(
-          id
-        ).populate('event');
+    if (!registration) {
+      return res.status(404).json({
+        message: 'Registration not found',
+      });
+    }
 
     // Owner check
     if (registration.user._id.toString() !== userId) {
       return res.status(403).json({
-        message: "Unauthorized",
+        message: 'Unauthorized',
       });
     }
 
-      // Owner check
-      if (
-        registration.user.toString() !==
-        userId
-      ) {
-        return res.status(403).json({
-          message: 'Unauthorized',
-        });
-      }
+    // Already cancelled
+    if (registration.status === 'cancelled') {
+      return res.status(400).json({
+        message: 'Already cancelled',
+      });
+    }
 
-      // Already cancelled
-      if (
-        registration.status ===
-        'cancelled'
-      ) {
-        return res.status(400).json({
-          message: 'Already cancelled',
-        });
-      }
+    const eventDate = new Date(registration.event.date);
+    if (eventDate < new Date()) {
+      return res.status(400).json({
+        message: 'Cannot cancel past events',
+      });
+    }
 
     let refundData = {
       refundStatus: 'not_applicable',
-      refundAmount: 0
-    }
+      refundAmount: 0,
+    };
 
     // Check if the event is paid or free
-    const isPaidEvent = registration.event.price && registration.event.price > 0;
+    const isPaidEvent =
+      registration.event.price && registration.event.price > 0;
 
     if (isPaidEvent) {
-      // Check if the event is more than 24 hours away (no refunds within 24 hours of event)
-      const refundPolicy = calculateRefund(eventDate, registration.event.price);
+      // Calculate refund based on policy
+      const refundPolicy = calculateRefund(
+        eventDate,
+        registration.event.price
+      );
 
       refundData = {
         refundStatus: refundPolicy.status,
-        refundAmount: refundPolicy.refundAmount
-      }
+        refundAmount: refundPolicy.refundAmount,
+      };
 
       if (refundPolicy.eligible && registration.paymentId) {
         try {
           // Call Razorpay Refund API with the stored paymentId
-          console.log("Refund API call...")
-          // TODO: Add after #76 merges
-          // Razorpay refund integration
-
-          /*
-          const refund =
-            await razorpay.payments.refund(
-              registration.paymentId,
-              {
-                amount:
-                  refundPolicy.refundAmount * 100,
-              }
-            );
-
-          refundData.refundId = refund.id;
-          refundData.refundStatus =
-            refund.status;
-          */
+          console.log('Refund API call...');
+          // TODO: Add after #76 merges Razorpay refund integration
 
           // Mock temporary response
-          refundData.refundId =
-            "mock_refund_id";
-          refundData.refundStatus =
-            "pending";
-          refundData.refundedAt =
-            new Date();
+          refundData.refundId = 'mock_refund_id';
+          refundData.refundStatus = 'pending';
+          refundData.refundedAt = new Date();
 
           // Send a refund confirmation email to the customer
           try {
-            await sendEmail({ to: req.user.email, subject: `Payment Refund : ${registration.event.title}`, html: `<p>You are refunded for ${registration.event.title} of total Amount : ${refundData.refundAmount}.</p>` });
-          } catch (_) { }
-
+            await sendEmail({
+              to: req.user.email,
+              subject: `Payment Refund: ${registration.event.title}`,
+              html: `<p>You are refunded for ${registration.event.title} of total Amount: ${refundData.refundAmount}.</p>`,
+            });
+          } catch (_) {}
         } catch (refundError) {
+          console.error('Refund Error:', refundError);
           return res.status(500).json({
-            message: "Refund processing failed",
+            message: 'Refund processing failed',
             error: refundError.message,
           });
-          console.log(refundError)
         }
       }
     }
 
-    // Save refund details: refundId, refundStatus, refundedAt to the Registration document
+    // Save refund details to the Registration document
     registration.refundId = refundData.refundId || null;
     registration.refundStatus = refundData.refundStatus;
     registration.refundAmount = refundData.refundAmount;
     registration.refundedAt = refundData.refundedAt || null;
 
-
-
-    registration.status = "cancelled";
+    registration.status = 'cancelled';
     await registration.save();
+
+    // Decrement registeredCount on event
+    await Event.findByIdAndUpdate(registration.event._id, {
+      $inc: { registeredCount: -1 },
+    });
+
+    // Auto-promote next person from waitlist
+    await promoteFromWaitlist(registration.event._id);
 
     res.status(200).json({
       message: 'Registration cancelled successfully',
       registration,
     });
   } catch (error) {
+    console.error('Cancel Registration Error:', error);
     res.status(500).json({ message: error.message });
   }
 };
@@ -757,49 +695,3 @@ export const checkRefundPolicy = async (req, res) => {
     });
   }
 };
-
-
-      // Past event check
-      const eventDate = new Date(
-        registration.event.date
-      );
-
-      if (eventDate < new Date()) {
-        return res.status(400).json({
-          message:
-            'Cannot cancel past events',
-        });
-      }
-
-      registration.status = 'cancelled';
-
-      await registration.save();
-
-      // Decrease registered count
-      await Event.findByIdAndUpdate(
-        registration.event._id,
-        {
-          $inc: {
-            registeredCount: -1,
-          },
-        }
-      );
-
-      // Promote next waitlisted user
-      await promoteFromWaitlist(
-        registration.event._id
-      );
-
-      res.status(200).json({
-        message:
-          'Registration cancelled successfully',
-        registration,
-      });
-    } catch (error) {
-      console.error('ERROR:', error);
-
-      res.status(500).json({
-        message: error.message,
-      });
-    }
-  };


### PR DESCRIPTION
Closes #281

This PR removes mistakenly merged duplicate code from both registerForEvent and cancelRegistration, ensuring that only the correct, atomic logic remains and that event registration and cancellation workflows are reliable and safe for high-concurrency usage.

### Changes Made
- Removed the broken first implementation in `registerForEvent` that used manual capacity checks, which could cause race conditions.
- Cleaned up unclosed or dangling `else` blocks and brackets that previously caused runtime errors and broken control flow.
- Retained only the atomic `findOneAndUpdate` implementation for capacity validation, providing robust handling of simultaneous requests.
- Fixed `cancelRegistration` logic, correcting the duplicate conflict and properly defining variables like `eventDate`.
- Restored the waitlist promotion logic so vacancies are refilled automatically when spots open up after cancellation.

### Why These Changes Were Needed
Previously, two versions of the registration logic were merged together, resulting in unreachable code, errors in registration/cancellation, and reliability issues when multiple users tried to register at the same time. Cancellation was also broken due to missing variable definitions.

### How It Was Fixed
- Deleted approximately 180 lines of redundant, buggy code, keeping only the atomic version.
- Prevented race conditions and handled duplicate registration errors gracefully (e.g., MongoDB error 11000).
- Triggered real-time dashboard updates using `emitRegistrationCount()`.
- Ensured cancelled registrations are properly reused, preserving audit trails and avoiding database conflicts.

### How to Test
1. Start the backend server using `npm run dev`.
2. Run a syntax check: `node --check src/controllers/registrationController.js` (no errors should appear).
3. Set an event capacity to 1, register a user, then attempt to register a second—the second should get "Event is full".
4. Cancel a registration and confirm that the event’s `registeredCount` is decremented in the database.

---

**Note:**  
Stage 1 may report a warning about use of a deprecated version of `actions/github-script@v7` in the repo workflow, but this is unrelated to this PR’s changes.

---

This version:
- Has a compliant title and sectioned, explicit description (well over 100 characters)
- Clearly explains the changes, rationale, and testing steps
- Includes a valid "Closes #281" line at the top

**Next:**  
Update your pull request description and title as shown above—these changes will make the automated validation pass, assuming the PR is based on a feature branch and the linked issue (#281) is open and assigned to you.