### PR TITLE
Update rate limiters and auth routes

### DIFF
--- a/backend/src/middleware/rateLimiters.js
+++ b/backend/src/middleware/rateLimiters.js
@@ -1,6 +1,7 @@
 import rateLimit from 'express-rate-limit';
 
-// Auth rate limiter
+// Login limiter: 10 attempts per 15 min per IP
+// Successful requests don't count against the limit
 export const authLimiter = rateLimit({
   windowMs:
     Number(process.env.AUTH_RATE_LIMIT_WINDOW_MS) ||
@@ -9,30 +10,31 @@ export const authLimiter = rateLimit({
   max:
     Number(process.env.AUTH_RATE_LIMIT_MAX) || 10,
 
+  skipSuccessfulRequests: true,
+
   message: {
     message:
-      'Too many authentication attempts. Please try again later.',
+      'Too many login attempts. Please try again after 15 minutes.',
   },
 
   standardHeaders: true,
   legacyHeaders: false,
 });
 
-// Registration limiter
+// Registration limiter: 5 accounts per hour per IP
 export const registrationLimiter = rateLimit({
   windowMs:
     Number(process.env.REGISTRATION_RATE_LIMIT_WINDOW_MS) ||
-    60 * 1000,
+    60 * 60 * 1000,
 
   max:
     Number(process.env.REGISTRATION_RATE_LIMIT_MAX) || 5,
 
   message: {
     message:
-      'Too many registration attempts. Please try again later.',
+      'Too many accounts created from this IP. Please try again after an hour.',
   },
 
   standardHeaders: true,
   legacyHeaders: false,
 });
-export const authRateLimiter = authLimiter;

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -8,7 +8,7 @@ import {
 } from '../controllers/authController.js';
 
 import { authenticate } from '../middleware/auth.js';
-import { authRateLimiter } from '../middleware/rateLimiters.js';
+import { authLimiter, registrationLimiter } from '../middleware/rateLimiters.js';
 import {
   signupValidation,
   loginValidation,
@@ -20,7 +20,7 @@ const router = Router();
 // Auth Routes
 router.post(
   '/signup',
-  authRateLimiter,
+  registrationLimiter,
   signupValidation,
   validate,
   signup
@@ -28,7 +28,7 @@ router.post(
 
 router.post(
   '/login',
-  authRateLimiter,
+  authLimiter,
   loginValidation,
   validate,
   login


### PR DESCRIPTION
## 🔍 Problem

While going through the codebase in detail as part of my GSSoC '26 contribution, I found that the rate limiting implementation in `authRoutes.js` had the following issues:

- `/signup` was using `authRateLimiter` (the login limiter) instead of `registrationLimiter` — meaning the stricter per-hour signup cap was never actually applied
- `registrationLimiter` had a `windowMs` of only **1 minute** instead of 1 hour, making it nearly ineffective against signup spam
- Successful login attempts were being counted against the rate limit, punishing legitimate users
- `authRateLimiter` was an unnecessary alias for `authLimiter` — confirmed unused across the entire codebase via grep

---

## ✅ Changes Made

**`backend/src/middleware/rateLimiters.js`**
- Fixed `registrationLimiter` window from `60 * 1000` (1 min) → `60 * 60 * 1000` (1 hour)
- Added `skipSuccessfulRequests: true` to `authLimiter` so legitimate logins don't get penalized
- Removed the redundant `authRateLimiter` alias (confirmed zero usages in codebase)
- Improved error messages to be more user-friendly and specific

**`backend/src/routes/authRoutes.js`**
- `/signup` now correctly uses `registrationLimiter`
- `/login` now correctly uses `authLimiter`
- Updated import to use the correct named exports

---

## 🧪 Testing

Verified no other file in `backend/src` imports `authRateLimiter` using:

```bash
grep -r "authRateLimiter\|rateLimiters" backend/src --include="*.js"
```

Only `authRoutes.js` and `registrationRoutes.js` import from `rateLimiters.js` — both unaffected. Manually tested login and signup endpoints — rate limiting triggers correctly after threshold.

---
