### PR TITLE
feat: add admin bulk actions for pending events

### DIFF
--- a/Frontendd/package-lock.json
+++ b/Frontendd/package-lock.json
@@ -95,7 +95,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3153,8 +3152,7 @@
         }
       ],
       "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsparticles/interaction-external-attract": {
       "version": "3.9.1",
@@ -3645,7 +3643,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3656,7 +3653,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3702,7 +3698,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4040,7 +4035,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4397,8 +4391,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4588,8 +4581,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4841,7 +4833,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6300,7 +6291,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7004,7 +6994,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7210,7 +7199,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7220,7 +7208,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8212,7 +8199,6 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -8301,7 +8287,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8624,7 +8609,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8764,7 +8748,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8999,7 +8982,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9223,7 +9205,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/Frontendd/src/pages/dashboard/AdminDashboard.jsx
+++ b/Frontendd/src/pages/dashboard/AdminDashboard.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Check, X, Calendar, MapPin, Building, Shield, Users, Activity, TrendingUp, Download, Trash2, MessageSquare, AlertTriangle } from 'lucide-react';
+import { Check, X, Calendar, MapPin, Building, Shield, Users, Activity, TrendingUp, Download, Trash2, MessageSquare, AlertTriangle, Loader2 } from 'lucide-react';
 import { Button } from '../../components/ui/button';
 import { Textarea } from '../../components/ui/textarea';
 import { useAuth } from '../../context/AuthContext';
+import toast from 'react-hot-toast';
 
 
 import { API_BASE_URL } from '../../config';
@@ -21,6 +22,13 @@ export default function AdminDashboard() {
     const [rejectReason, setRejectReason] = useState('');
     const [rejectLoading, setRejectLoading] = useState(false);
     const mountedRef = useRef(true);
+
+    // Bulk action state
+    const [selectedIds, setSelectedIds] = useState(new Set());
+    const [bulkLoading, setBulkLoading] = useState(null);
+    const [bulkProgress, setBulkProgress] = useState({ action: '', completed: 0, total: 0 });
+    const [bulkRejectOpen, setBulkRejectOpen] = useState(false);
+    const [bulkRejectReason, setBulkRejectReason] = useState('');
 
     useEffect(() => {
         return () => {
@@ -243,6 +251,91 @@ export default function AdminDashboard() {
         }
     };
 
+    // --- Bulk Action Helpers ---
+
+    const selectedCount = selectedIds.size;
+
+    const toggleSelectId = (id) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    };
+
+    const toggleSelectAll = () => {
+        if (selectedIds.size === pendingEvents.length) {
+            setSelectedIds(new Set());
+        } else {
+            setSelectedIds(new Set(pendingEvents.map(e => e._id)));
+        }
+    };
+
+    const runBulkAction = async (action, extraBody = {}) => {
+        const ids = [...selectedIds];
+        if (ids.length === 0) return;
+
+        setBulkLoading(action);
+        setBulkProgress({ action, completed: 0, total: ids.length });
+
+        try {
+            const token = localStorage.getItem('token');
+            const res = await fetch(`${API_BASE_URL}/api/admin/events/bulk-${action}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: JSON.stringify({ eventIds: ids, ...extraBody }),
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                toast.error(data.message || `Bulk ${action} failed`);
+                return;
+            }
+
+            setBulkProgress({ action, completed: data.succeeded, total: ids.length });
+
+            if (data.failed === 0) {
+                toast.success(`${data.succeeded} event${data.succeeded > 1 ? 's' : ''} ${action}${action === 'approve' ? 'd' : action === 'reject' ? 'ed' : 'd'} successfully`);
+            } else {
+                toast.error(`${data.succeeded} succeeded, ${data.failed} failed`);
+            }
+
+            setSelectedIds(new Set());
+            fetchPendingEvents();
+            fetchStats();
+        } catch (error) {
+            console.error(`Bulk ${action} failed`, error);
+            toast.error(`Bulk ${action} failed. Please try again.`);
+        } finally {
+            setBulkLoading(null);
+            setBulkProgress({ action: '', completed: 0, total: 0 });
+        }
+    };
+
+    const handleBulkRejectSubmit = async () => {
+        if (bulkRejectReason.trim().length < 20) return;
+        await runBulkAction('reject', { rejectionReason: bulkRejectReason.trim() });
+        setBulkRejectOpen(false);
+        setBulkRejectReason('');
+    };
+
+    const handleBulkDelete = () => {
+        const count = selectedIds.size;
+        if (!window.confirm(`Are you sure you want to permanently delete ${count} event${count > 1 ? 's' : ''}? This action cannot be undone.`)) {
+            return;
+        }
+        runBulkAction('delete');
+    };
+
+
     if (loading) {
         return (
             <div className="flex items-center justify-center min-h-screen bg-[#09090b]">
@@ -342,6 +435,21 @@ export default function AdminDashboard() {
                                         <p className="text-muted-foreground italic text-sm">No pending events to review at the moment.</p>
                                     </motion.div>
                                 ) : (
+                                    <>
+                                    {/* Select All Bar */}
+                                    <div className="flex items-center gap-3 px-2 py-3 rounded-xl bg-secondary/30 border border-border mb-2">
+                                        <label className="flex items-center gap-2 cursor-pointer select-none">
+                                            <input
+                                                type="checkbox"
+                                                checked={pendingEvents.length > 0 && selectedIds.size === pendingEvents.length}
+                                                onChange={toggleSelectAll}
+                                                className="w-4 h-4 rounded border-border accent-purple-500 cursor-pointer"
+                                            />
+                                            <span className="text-sm text-muted-foreground">
+                                                {selectedCount > 0 ? `${selectedCount} of ${pendingEvents.length} selected` : 'Select All'}
+                                            </span>
+                                        </label>
+                                    </div>
                                     <div className="grid grid-cols-1 gap-6">
                                         {pendingEvents.map((event, idx) => (
                                             <motion.div
@@ -351,8 +459,24 @@ export default function AdminDashboard() {
                                                 animate={{ opacity: 1, y: 0 }}
                                                 exit={{ opacity: 0, scale: 0.95 }}
                                                 transition={{ delay: idx * 0.05 }}
-                                                className="group relative bg-card border border-border rounded-2xl p-4 hover:border-purple-500/50 transition-colors shadow-sm"
+                                                className={`group relative bg-card border rounded-2xl p-4 transition-colors shadow-sm ${
+                                                    selectedIds.has(event._id)
+                                                        ? 'border-purple-500 bg-purple-500/5'
+                                                        : 'border-border hover:border-purple-500/50'
+                                                }`}
                                             >
+                                                {/* Selection Checkbox */}
+                                                <div className="absolute top-3 left-3 z-10">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={selectedIds.has(event._id)}
+                                                        onChange={(e) => {
+                                                            e.stopPropagation();
+                                                            toggleSelectId(event._id);
+                                                        }}
+                                                        className="w-4 h-4 rounded border-border accent-purple-500 cursor-pointer"
+                                                    />
+                                                </div>
                                                 <div className="flex flex-col md:flex-row gap-6">
                                                     {/* Poster */}
                                                     <div className="w-full md:w-56 h-36 rounded-xl overflow-hidden shrink-0 bg-muted relative">
@@ -427,6 +551,7 @@ export default function AdminDashboard() {
                                             </motion.div>
                                         ))}
                                     </div>
+                                    </>
                                 )}
                             </div>
                         )}
@@ -554,6 +679,139 @@ export default function AdminDashboard() {
                     </AnimatePresence>
                 </div>
             </div>
+
+            {/* Floating Bulk Action Bar */}
+            <AnimatePresence>
+                {selectedCount > 0 && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 40 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: 40 }}
+                        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                        className="fixed bottom-6 left-1/2 z-50 w-[95%] max-w-3xl -translate-x-1/2 rounded-2xl border border-border bg-card/95 p-4 shadow-2xl backdrop-blur-md"
+                    >
+                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                            <div className="text-sm text-foreground">
+                                <span className="font-semibold">{selectedCount}</span> event{selectedCount > 1 ? 's' : ''} selected
+                                {bulkLoading && (
+                                    <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        {bulkProgress.action === 'approve' && `Approving ${bulkProgress.completed} of ${bulkProgress.total}...`}
+                                        {bulkProgress.action === 'reject' && `Rejecting ${bulkProgress.completed} of ${bulkProgress.total}...`}
+                                        {bulkProgress.action === 'delete' && `Deleting ${bulkProgress.completed} of ${bulkProgress.total}...`}
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="flex flex-wrap items-center gap-2">
+                                <Button
+                                    size="sm"
+                                    onClick={() => runBulkAction('approve')}
+                                    disabled={Boolean(bulkLoading)}
+                                    className="bg-green-600 text-white hover:bg-green-700"
+                                >
+                                    ✅ Approve Selected ({selectedCount})
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => setBulkRejectOpen(true)}
+                                    disabled={Boolean(bulkLoading)}
+                                    className="border-red-500/30 text-red-600 hover:bg-red-500/10"
+                                >
+                                    ❌ Reject Selected ({selectedCount})
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={handleBulkDelete}
+                                    disabled={Boolean(bulkLoading)}
+                                    className="border-zinc-500/30 text-zinc-400 hover:bg-zinc-500/10"
+                                >
+                                    🗑 Delete Selected ({selectedCount})
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={() => setSelectedIds(new Set())}
+                                    disabled={Boolean(bulkLoading)}
+                                    className="text-muted-foreground"
+                                >
+                                    Clear
+                                </Button>
+                            </div>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {/* Bulk Reject Modal */}
+            <AnimatePresence>
+                {bulkRejectOpen && (
+                    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+                        <motion.div
+                            initial={{ opacity: 0, scale: 0.95 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.95 }}
+                            className="bg-white text-zinc-950 w-full max-w-lg rounded-2xl border border-zinc-200 shadow-2xl overflow-hidden"
+                        >
+                            <div className="p-6">
+                                <div className="flex justify-between items-start gap-4 mb-6">
+                                    <div>
+                                        <h3 className="text-2xl font-bold text-zinc-900">Reject Selected Events</h3>
+                                        <p className="text-zinc-500 text-sm mt-1">This reason will be applied to all {selectedCount} selected event{selectedCount > 1 ? 's' : ''}.</p>
+                                    </div>
+                                    <button
+                                        onClick={() => {
+                                            if (bulkLoading) return;
+                                            setBulkRejectOpen(false);
+                                            setBulkRejectReason('');
+                                        }}
+                                        className="text-zinc-400 hover:text-zinc-900"
+                                    >
+                                        <X className="w-5 h-5" />
+                                    </button>
+                                </div>
+
+                                <div className="space-y-3">
+                                    <label className="text-sm font-medium text-zinc-800">
+                                        Reason for rejection
+                                    </label>
+                                    <Textarea
+                                        value={bulkRejectReason}
+                                        onChange={(e) => setBulkRejectReason(e.target.value)}
+                                        placeholder="Provide a reason for rejecting these events..."
+                                        className="min-h-[140px] bg-zinc-50 border-zinc-200"
+                                    />
+                                    <div className={`text-xs ${bulkRejectReason.trim().length >= 20 ? 'text-green-600' : 'text-zinc-500'}`}>
+                                        {bulkRejectReason.trim().length}/20 characters minimum
+                                    </div>
+                                </div>
+
+                                <div className="flex justify-end gap-3 mt-6">
+                                    <Button
+                                        variant="outline"
+                                        onClick={() => {
+                                            setBulkRejectOpen(false);
+                                            setBulkRejectReason('');
+                                        }}
+                                        disabled={Boolean(bulkLoading)}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        onClick={handleBulkRejectSubmit}
+                                        disabled={Boolean(bulkLoading) || bulkRejectReason.trim().length < 20}
+                                        className="bg-red-600 hover:bg-red-700 text-white"
+                                    >
+                                        {bulkLoading === 'reject' ? 'Rejecting...' : `Reject ${selectedCount} Event${selectedCount > 1 ? 's' : ''}`}
+                                    </Button>
+                                </div>
+                            </div>
+                        </motion.div>
+                    </div>
+                )}
+            </AnimatePresence>
 
             {/* Manage Event Modal */}
             <AnimatePresence>

--- a/backend/src/__tests__/admin.bulk.test.js
+++ b/backend/src/__tests__/admin.bulk.test.js
@@ -1,0 +1,312 @@
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+const mockEvent = {
+  findByIdAndUpdate: jest.fn(),
+  findById: jest.fn(),
+  findByIdAndDelete: jest.fn(),
+};
+
+const mockSendEventRejectionEmail = jest.fn();
+const mockCreateNotification = jest.fn();
+const mockDeleteFromCloudinary = jest.fn();
+
+jest.unstable_mockModule('../models/Event.js', () => ({
+  default: mockEvent,
+}));
+
+jest.unstable_mockModule('../models/User.js', () => ({
+  default: {},
+}));
+
+jest.unstable_mockModule('../utils/email.js', () => ({
+  sendEventRejectionEmail: mockSendEventRejectionEmail,
+}));
+
+jest.unstable_mockModule('./notificationController.js', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+jest.unstable_mockModule('../config/cloudinary.js', () => ({
+  deleteFromCloudinary: mockDeleteFromCloudinary,
+}));
+
+const { bulkApproveEvents, bulkRejectEvents, bulkDeleteEvents } = await import(
+  '../controllers/adminController.js'
+);
+
+// --- Helpers ---
+
+const VALID_ID_1 = '507f1f77bcf86cd799439011';
+const VALID_ID_2 = '507f1f77bcf86cd799439012';
+const VALID_ID_3 = '507f1f77bcf86cd799439013';
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const mockReq = (body) => ({ body });
+
+// --- Tests ---
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// =====================
+// bulkApproveEvents
+// =====================
+
+describe('bulkApproveEvents', () => {
+  it('should approve multiple events successfully', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1, VALID_ID_2] });
+    const res = mockRes();
+
+    const fakeEvent1 = {
+      _id: VALID_ID_1,
+      title: 'Event 1',
+      organizer: { _id: 'org1', name: 'Org', email: 'org@test.com' },
+    };
+    const fakeEvent2 = {
+      _id: VALID_ID_2,
+      title: 'Event 2',
+      organizer: { _id: 'org2', name: 'Org2', email: 'org2@test.com' },
+    };
+
+    mockEvent.findByIdAndUpdate
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(fakeEvent1) })
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(fakeEvent2) });
+
+    await bulkApproveEvents(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      succeeded: 2,
+      failed: 0,
+      errors: [],
+    });
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return 400 when eventIds is an empty array', async () => {
+    const req = mockReq({ eventIds: [] });
+    const res = mockRes();
+
+    await bulkApproveEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'eventIds must be a non-empty array',
+    });
+  });
+
+  it('should return 400 when eventIds is not an array', async () => {
+    const req = mockReq({ eventIds: 'not-an-array' });
+    const res = mockRes();
+
+    await bulkApproveEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'eventIds must be a non-empty array',
+    });
+  });
+
+  it('should return 400 when eventIds contains invalid ObjectIds', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1, 'invalid-id'] });
+    const res = mockRes();
+
+    await bulkApproveEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'One or more eventIds are invalid',
+      invalidIds: ['invalid-id'],
+    });
+  });
+
+  it('should handle partial failures (some events not found)', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1, VALID_ID_2] });
+    const res = mockRes();
+
+    const fakeEvent1 = {
+      _id: VALID_ID_1,
+      title: 'Event 1',
+      organizer: { _id: 'org1', name: 'Org', email: 'org@test.com' },
+    };
+
+    mockEvent.findByIdAndUpdate
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(fakeEvent1) })
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(null) });
+
+    await bulkApproveEvents(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      succeeded: 1,
+      failed: 1,
+      errors: [{ eventId: VALID_ID_2, error: 'Event not found' }],
+    });
+  });
+});
+
+// =====================
+// bulkRejectEvents
+// =====================
+
+describe('bulkRejectEvents', () => {
+  const VALID_REASON = 'This event does not meet our community guidelines and standards';
+
+  it('should reject multiple events with valid reason', async () => {
+    const req = mockReq({
+      eventIds: [VALID_ID_1, VALID_ID_2],
+      rejectionReason: VALID_REASON,
+    });
+    const res = mockRes();
+
+    const makeEvent = (id, title) => ({
+      _id: id,
+      title,
+      status: 'pending',
+      rejectionReason: '',
+      organizer: { _id: `org-${id}`, name: 'Org', email: 'org@test.com' },
+      save: jest.fn().mockResolvedValue(true),
+    });
+
+    const event1 = makeEvent(VALID_ID_1, 'Event 1');
+    const event2 = makeEvent(VALID_ID_2, 'Event 2');
+
+    mockEvent.findById
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(event1) })
+      .mockReturnValueOnce({ populate: jest.fn().mockResolvedValue(event2) });
+
+    await bulkRejectEvents(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      succeeded: 2,
+      failed: 0,
+      errors: [],
+    });
+    expect(event1.save).toHaveBeenCalled();
+    expect(event2.save).toHaveBeenCalled();
+    expect(mockSendEventRejectionEmail).toHaveBeenCalledTimes(2);
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return 400 when rejection reason is too short', async () => {
+    const req = mockReq({
+      eventIds: [VALID_ID_1],
+      rejectionReason: 'Too short',
+    });
+    const res = mockRes();
+
+    await bulkRejectEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Rejection reason is required and must be at least 20 characters long',
+    });
+  });
+
+  it('should return 400 when rejection reason is missing', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1] });
+    const res = mockRes();
+
+    await bulkRejectEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Rejection reason is required and must be at least 20 characters long',
+    });
+  });
+
+  it('should return 400 when eventIds is empty', async () => {
+    const req = mockReq({ eventIds: [], rejectionReason: VALID_REASON });
+    const res = mockRes();
+
+    await bulkRejectEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'eventIds must be a non-empty array',
+    });
+  });
+});
+
+// =====================
+// bulkDeleteEvents
+// =====================
+
+describe('bulkDeleteEvents', () => {
+  it('should delete multiple events and call deleteFromCloudinary for events with posterUrl', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1, VALID_ID_2] });
+    const res = mockRes();
+
+    mockEvent.findByIdAndDelete
+      .mockResolvedValueOnce({
+        _id: VALID_ID_1,
+        posterUrl: 'https://res.cloudinary.com/demo/image/upload/v123/eventone/posters/poster1.webp',
+      })
+      .mockResolvedValueOnce({
+        _id: VALID_ID_2,
+        posterUrl: null,
+      });
+
+    await bulkDeleteEvents(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      succeeded: 2,
+      failed: 0,
+      errors: [],
+    });
+    expect(mockDeleteFromCloudinary).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFromCloudinary).toHaveBeenCalledWith(
+      'https://res.cloudinary.com/demo/image/upload/v123/eventone/posters/poster1.webp'
+    );
+  });
+
+  it('should return 400 when eventIds is empty', async () => {
+    const req = mockReq({ eventIds: [] });
+    const res = mockRes();
+
+    await bulkDeleteEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'eventIds must be a non-empty array',
+    });
+  });
+
+  it('should return 400 when eventIds contains invalid ObjectIds', async () => {
+    const req = mockReq({ eventIds: ['bad-id'] });
+    const res = mockRes();
+
+    await bulkDeleteEvents(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'One or more eventIds are invalid',
+      invalidIds: ['bad-id'],
+    });
+  });
+
+  it('should handle partial failure when some events are not found', async () => {
+    const req = mockReq({ eventIds: [VALID_ID_1, VALID_ID_2, VALID_ID_3] });
+    const res = mockRes();
+
+    mockEvent.findByIdAndDelete
+      .mockResolvedValueOnce({ _id: VALID_ID_1, posterUrl: null })
+      .mockResolvedValueOnce(null) // not found
+      .mockResolvedValueOnce({ _id: VALID_ID_3, posterUrl: null });
+
+    await bulkDeleteEvents(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      succeeded: 2,
+      failed: 1,
+      errors: [{ eventId: VALID_ID_2, error: 'Event not found' }],
+    });
+  });
+});

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,7 +1,9 @@
+import mongoose from 'mongoose';
 import Event from '../models/Event.js';
 import User from '../models/User.js';
 import { sendEventRejectionEmail } from '../utils/email.js';
 import { createNotification } from './notificationController.js';
+import { deleteFromCloudinary } from '../config/cloudinary.js';
 
 export const approveEvent = async (req, res) => {
   try {
@@ -122,6 +124,199 @@ export const updateUserRole = async (req, res) => {
     const user = await User.findByIdAndUpdate(req.params.id, { role }, { new: true });
     if (!user) return res.status(404).json({ message: 'User not found' });
     res.json({ user });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// --- Bulk Action Helpers ---
+
+const getBulkEventIds = (eventIds = []) => {
+  const uniqueIds = [...new Set(eventIds.filter(Boolean))];
+  const invalidIds = uniqueIds.filter(
+    (id) => !mongoose.Types.ObjectId.isValid(id)
+  );
+  return { uniqueIds, invalidIds };
+};
+
+const buildBulkSummary = (results, eventIds) => {
+  let succeeded = 0;
+  let failed = 0;
+  const errors = [];
+
+  results.forEach((result, index) => {
+    const eventId = eventIds[index];
+    if (result.status === 'fulfilled') {
+      succeeded += 1;
+      return;
+    }
+    failed += 1;
+    errors.push({
+      eventId,
+      error: result.reason?.message || 'Unknown error',
+    });
+  });
+
+  return { succeeded, failed, errors };
+};
+
+// --- Bulk Approve ---
+
+export const bulkApproveEvents = async (req, res) => {
+  try {
+    const { eventIds } = req.body || {};
+
+    if (!Array.isArray(eventIds) || eventIds.length === 0) {
+      return res.status(400).json({ message: 'eventIds must be a non-empty array' });
+    }
+
+    const { uniqueIds, invalidIds } = getBulkEventIds(eventIds);
+
+    if (invalidIds.length > 0) {
+      return res.status(400).json({
+        message: 'One or more eventIds are invalid',
+        invalidIds,
+      });
+    }
+
+    const results = await Promise.allSettled(
+      uniqueIds.map(async (eventId) => {
+        const event = await Event.findByIdAndUpdate(
+          eventId,
+          { status: 'approved', rejectionReason: '' },
+          { new: true }
+        ).populate('organizer', 'name email');
+
+        if (!event) {
+          throw new Error('Event not found');
+        }
+
+        if (event.organizer) {
+          try {
+            await createNotification(
+              event.organizer._id,
+              'event_approved',
+              `Your event ${event.title} has been approved`,
+              `/events/${event._id}`
+            );
+          } catch (notifErr) {
+            console.error('Failed to create bulk approval notification:', notifErr);
+          }
+        }
+      })
+    );
+
+    res.json(buildBulkSummary(results, uniqueIds));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// --- Bulk Reject ---
+
+export const bulkRejectEvents = async (req, res) => {
+  try {
+    const { eventIds, rejectionReason } = req.body || {};
+    const reason = rejectionReason?.trim();
+
+    if (!Array.isArray(eventIds) || eventIds.length === 0) {
+      return res.status(400).json({ message: 'eventIds must be a non-empty array' });
+    }
+
+    if (!reason || reason.length < 20) {
+      return res.status(400).json({
+        message: 'Rejection reason is required and must be at least 20 characters long',
+      });
+    }
+
+    const { uniqueIds, invalidIds } = getBulkEventIds(eventIds);
+
+    if (invalidIds.length > 0) {
+      return res.status(400).json({
+        message: 'One or more eventIds are invalid',
+        invalidIds,
+      });
+    }
+
+    const results = await Promise.allSettled(
+      uniqueIds.map(async (eventId) => {
+        const event = await Event.findById(eventId).populate('organizer', 'name email');
+
+        if (!event) {
+          throw new Error('Event not found');
+        }
+
+        event.status = 'rejected';
+        event.rejectionReason = reason;
+        await event.save();
+
+        if (event.organizer?.email) {
+          try {
+            await sendEventRejectionEmail(event.organizer.email, event, reason);
+          } catch (emailError) {
+            console.warn(`Failed to send rejection email for event ${event._id}: ${emailError.message}`);
+          }
+        }
+
+        if (event.organizer) {
+          try {
+            await createNotification(
+              event.organizer._id,
+              'event_rejected',
+              `Your event ${event.title} was not approved`,
+              `/events/${event._id}`
+            );
+          } catch (notifErr) {
+            console.error('Failed to create bulk rejection notification:', notifErr);
+          }
+        }
+      })
+    );
+
+    res.json(buildBulkSummary(results, uniqueIds));
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// --- Bulk Delete ---
+
+export const bulkDeleteEvents = async (req, res) => {
+  try {
+    const { eventIds } = req.body || {};
+
+    if (!Array.isArray(eventIds) || eventIds.length === 0) {
+      return res.status(400).json({ message: 'eventIds must be a non-empty array' });
+    }
+
+    const { uniqueIds, invalidIds } = getBulkEventIds(eventIds);
+
+    if (invalidIds.length > 0) {
+      return res.status(400).json({
+        message: 'One or more eventIds are invalid',
+        invalidIds,
+      });
+    }
+
+    const results = await Promise.allSettled(
+      uniqueIds.map(async (eventId) => {
+        const deleted = await Event.findByIdAndDelete(eventId);
+
+        if (!deleted) {
+          throw new Error('Event not found');
+        }
+
+        if (deleted.posterUrl) {
+          try {
+            await deleteFromCloudinary(deleted.posterUrl);
+          } catch (cloudinaryError) {
+            console.warn(`Failed to delete poster for event ${deleted._id}: ${cloudinaryError.message}`);
+          }
+        }
+      })
+    );
+
+    res.json(buildBulkSummary(results, uniqueIds));
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,12 +1,15 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/auth.js';
 import { authorizeRoles } from '../middleware/roles.js';
-import { approveEvent, rejectEvent, listPendingEvents, blockUser, unblockUser, getAllUsers, updateUserRole } from '../controllers/adminController.js';
+import { approveEvent, rejectEvent, listPendingEvents, blockUser, unblockUser, getAllUsers, updateUserRole, bulkApproveEvents, bulkRejectEvents, bulkDeleteEvents } from '../controllers/adminController.js';
 
 const router = Router();
 
 router.use(authenticate, authorizeRoles('admin'));
 router.get('/events/pending', listPendingEvents);
+router.post('/events/bulk-approve', bulkApproveEvents);
+router.post('/events/bulk-reject', bulkRejectEvents);
+router.post('/events/bulk-delete', bulkDeleteEvents);
 router.post('/events/:id/approve', approveEvent);
 router.post('/events/:id/reject', rejectEvent);
 router.post('/users/:id/block', blockUser);


### PR DESCRIPTION
This PR implements the requested bulk action features for the admin dashboard. Admins can now select multiple pending events using the new checkboxes on each event card. Once selected, a floating action bar appears at the bottom allowing bulk approve, bulk reject, and bulk delete actions.

I have updated the backend to support these new endpoints using `Promise.allSettled` to ensure that if one event processing fails, the remaining events are still processed. Frontend state management, UI, and toasts have been properly implemented.

Closes #94

### Testing Steps
1. Start the application locally with `npm run dev` in both the frontend and backend directories.
2. Login as an admin and navigate to the pending events tab.
3. Check multiple boxes on the event cards.
4. Click the "Approve Selected" or "Reject Selected" buttons and confirm the toast notifications show success.
5. Verify that the correct API requests were made and that the events are updated on the dashboard.