### PR TITLE
fix: prevent crash when waitlist is empty

### DIFF
--- a/backend/src/controllers/registrationController.js
+++ b/backend/src/controllers/registrationController.js
@@ -413,6 +413,9 @@ export const promoteFromWaitlist = async (eventId) => {
     .sort({ createdAt: 1 })
     .populate('user')
     .populate('event');
+    if (!nextRegistration) {
+  return;
+}
 
     const payload = JSON.stringify({
       userId:


### PR DESCRIPTION
## Description

Closes #333

Added a null check in `promoteFromWaitlist()` before accessing `nextRegistration.user._id`.

Previously, when no waitlisted registration existed, the function could throw a TypeError due to accessing properties of a null object. This change ensures the function exits safely when no eligible waitlisted user is found.

## Type of Change

- [x] Bug fix

## Testing

- Tested with existing waitlisted registrations
- Tested with no waitlisted registrations
- Verified no TypeError is thrown