### PR TITLE
fix: replace Twitter bird icon with X logo in footer

### DIFF
--- a/Frontendd/src/components/mvpblocks/footer-standard.jsx
+++ b/Frontendd/src/components/mvpblocks/footer-standard.jsx
@@ -9,13 +9,20 @@ import toast from "react-hot-toast";
 import {
   Github,
   Linkedin,
-  Twitter,
   MessageCircle,
   Zap,
   Heart,
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+
+function XIcon({ size = 18 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.747l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
 
 const data = () => ({
   navigation: {
@@ -43,7 +50,7 @@ const data = () => ({
   },
 
   socialLinks: [
-    { icon: Twitter, label: "Twitter", href: "#" },
+    { icon: XIcon, label: "X", href: "#" },
     { icon: Github, label: "GitHub", href: "#" },
     { icon: MessageCircle, label: "Discord", href: "#" },
     { icon: Linkedin, label: "LinkedIn", href: "#" },


### PR DESCRIPTION
## Summary
Replaced the outdated Twitter bird icon with the official X (formerly Twitter) logo in the footer social media icons row.

## Changes Made
- Removed `Twitter` import from `lucide-react`
- Added custom `XIcon` component using the official X SVG path
- Updated `socialLinks` entry: icon → `XIcon`, label → `"X"`

## Note
`lucide-react` does not include an X icon, so a lightweight inline SVG component was used, no new dependencies added.

Closes #303

## Type of Change
- [x] Bug fix / UI update (non-breaking)

## Testing

- Local dev server had pre-existing dependency issues unrelated to this change.
- Code change verified via grep and manual review of the file.