### PR TITLE
fix(events): escape regex metacharacters in listEvents search to prevent ReDoS

### DIFF
--- a/backend/src/controllers/eventController.js
+++ b/backend/src/controllers/eventController.js
@@ -208,8 +208,10 @@ export const listEvents = async (req, res) => {
     const filter = {};
 
     if (q) {
+      // Escape regex special chars to prevent NoSQL/ReDoS injection (CWE-943)
+      const escapedQ = String(q).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       filter.title = {
-        $regex: q,
+        $regex: escapedQ,
         $options: 'i',
       };
     }


### PR DESCRIPTION
## Summary

The public `GET /api/events` endpoint (defined in `backend/src/routes/eventRoutes.js` as `router.get('/', listEvents)`) accepts a `q` query parameter and passes it directly as a `$regex` pattern to Mongoose in `listEvents` (`backend/src/controllers/eventController.js`). Because the value is used as a regex source rather than a literal string, an unauthenticated attacker can supply an evil regex that triggers catastrophic backtracking against every event title in the collection, exhausting Node's event loop and DoS'ing the API (a ReDoS variant of CWE-943 / CWE-1333).

## Vulnerable code (before)

```js
if (q) {
  filter.title = {
    $regex: q,        // attacker-controlled regex source
    $options: 'i',
  };
}
```

While `String(q)` coercion elsewhere would block operator injection like `{$ne: ...}`, it does not neutralize regex metacharacters. The `$regex` operator interprets the value as a PCRE-like pattern.

## Proof of Concept

No auth is required. The route `router.get('/', listEvents)` in `backend/src/routes/eventRoutes.js` is mounted publicly (unlike sibling routers such as `userRoutes.js` and `adminRoutes.js` which apply `router.use(authenticate, ...)`).

```bash
# Baseline — returns quickly
time curl -s 'http://localhost:5000/api/events?q=meetup' >/dev/null

# Malicious pattern — catastrophic backtracking against every title
time curl -s "http://localhost:5000/api/events?q=%28a%2B%29%2B%24" >/dev/null

# Repeat in parallel to stall the single Node event loop:
for i in $(seq 1 10); do
  curl -s "http://localhost:5000/api/events?q=%28a%2B%29%2B%24" >/dev/null &
done; wait
```

With even a small seeded dataset containing titles matching `aaaa...`, response times balloon from milliseconds to many seconds per request, and concurrent requests stall the API for all other users.

## Fix

Escape regex metacharacters before handing the value to `$regex`, converting the query into a literal case-insensitive substring match — which is what the endpoint's UX clearly intends:

```js
if (q) {
  const escapedQ = String(q).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
  filter.title = { $regex: escapedQ, $options: 'i' };
}
```

Diff is 3 lines in a single file. Behaviour for benign queries is unchanged; only regex metacharacters lose their special meaning, which matches user expectations for a search box.

## Testing

- Verified the endpoint routing (`router.get('/', listEvents)`) and confirmed no `authenticate` middleware is applied at the router or app level for `/api/events`.
- Manually confirmed that with the patch applied, `q=(a+)+$` is matched literally against titles and returns instantly regardless of dataset shape.
- Confirmed no other code path re-introduces raw user input into a Mongoose `$regex` for the `title` field.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether an upstream WAF/framework mitigation exists (none — Express + Mongoose, no rate limiter on this route), whether the `String()` coercion elsewhere already blocks the attack (it doesn't — it prevents operator injection, not ReDoS), and whether a Mongo-side regex engine limit would save you (MongoDB evaluates `$regex` per-document with no default timeout, so a bad pattern scales linearly with collection size). We also confirmed the route is genuinely public by comparing against `userRoutes.js`/`adminRoutes.js` which do apply `router.use(authenticate, ...)`. None of these mitigations are in place, so the finding stands.

---





Closes #143